### PR TITLE
WrenSec Builds - Phase #1 (for DS sustaining/3.0.0)

### DIFF
--- a/.wren-deploy.rc
+++ b/.wren-deploy.rc
@@ -1,0 +1,14 @@
+export MAVEN_PACKAGE="opendj"
+export BINTRAY_PACKAGE="wrends"
+export JFROG_PACKAGE="org/forgerock/opendj"
+
+package_accept_release_tag() {
+  local tag_name="${1}"
+
+  if [ "${tag_name}" != "3.0.0" ]; then
+    echo "Skipping ${tag_name} since we only want to build 3.x right now."
+    return -1
+  else
+    return 0
+  fi
+}

--- a/opendj-config/pom.xml
+++ b/opendj-config/pom.xml
@@ -33,7 +33,7 @@
     <version>3.0.0</version>
   </parent>
   <artifactId>opendj-config</artifactId>
-  <name>WrenDS Configuration API</name>
+  <name>Wren:DS Configuration API</name>
   <description>
     This module includes Configuration APIs for implementing LDAP Directory
     client and server applications.

--- a/opendj-config/pom.xml
+++ b/opendj-config/pom.xml
@@ -22,6 +22,7 @@
   ! CDDL HEADER END
   !
   !      Copyright 2013-2015 ForgeRock AS.
+  !      Portions Copyright 2017 Wren Security.
   !
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -32,7 +33,7 @@
     <version>3.0.0</version>
   </parent>
   <artifactId>opendj-config</artifactId>
-  <name>OpenDJ Configuration API</name>
+  <name>WrenDS Configuration API</name>
   <description>
     This module includes Configuration APIs for implementing LDAP Directory
     client and server applications.

--- a/opendj-dsml-servlet/pom.xml
+++ b/opendj-dsml-servlet/pom.xml
@@ -35,8 +35,8 @@
     </parent>
 
     <artifactId>opendj-dsml-servlet</artifactId>
-    <name>WrenDS DSML Gateway</name>
-    <description>WrenDS DSML Gateway</description>
+    <name>Wren:DS DSML Gateway</name>
+    <description>Wren:DS DSML Gateway</description>
     <packaging>war</packaging>
 
     <properties>
@@ -61,7 +61,7 @@
             <artifactId>i18n-slf4j</artifactId>
         </dependency>
 
-        <!-- WrenDS SDK dependencies -->
+        <!-- Wren:DS SDK dependencies -->
         <dependency>
             <groupId>org.forgerock.opendj</groupId>
             <artifactId>opendj-cli</artifactId>
@@ -72,7 +72,7 @@
             <artifactId>opendj-core</artifactId>
         </dependency>
 
-        <!-- WrenDS Server dependencies -->
+        <!-- Wren:DS Server dependencies -->
         <dependency>
             <groupId>org.forgerock.opendj</groupId>
             <artifactId>opendj-config</artifactId>

--- a/opendj-dsml-servlet/pom.xml
+++ b/opendj-dsml-servlet/pom.xml
@@ -22,6 +22,7 @@
   ! CDDL HEADER END
   !
   !      Copyright 2015 ForgeRock AS.
+  !      Portions Copyright 2017 Wren Security.
   !
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -34,8 +35,8 @@
     </parent>
 
     <artifactId>opendj-dsml-servlet</artifactId>
-    <name>OpenDJ DSML Gateway</name>
-    <description>OpenDJ DSML Gateway</description>
+    <name>WrenDS DSML Gateway</name>
+    <description>WrenDS DSML Gateway</description>
     <packaging>war</packaging>
 
     <properties>
@@ -60,7 +61,7 @@
             <artifactId>i18n-slf4j</artifactId>
         </dependency>
 
-        <!-- OpenDJ SDK dependencies -->
+        <!-- WrenDS SDK dependencies -->
         <dependency>
             <groupId>org.forgerock.opendj</groupId>
             <artifactId>opendj-cli</artifactId>
@@ -71,7 +72,7 @@
             <artifactId>opendj-core</artifactId>
         </dependency>
 
-        <!-- OpenDJ Server dependencies -->
+        <!-- WrenDS Server dependencies -->
         <dependency>
             <groupId>org.forgerock.opendj</groupId>
             <artifactId>opendj-config</artifactId>

--- a/opendj-legacy/pom.xml
+++ b/opendj-legacy/pom.xml
@@ -24,9 +24,9 @@
     <version>3.0.0</version>
   </parent>
   <artifactId>opendj-legacy</artifactId>
-  <name>WrenDS Legacy</name>
+  <name>Wren:DS Legacy</name>
   <description>
-    This module contains WrenDS legacy code that needs to be kept for compatibility reasons
+    This module contains Wren:DS legacy code that needs to be kept for compatibility reasons
     but will never be used again. DO NOT USE THIS CODE AT ALL, it could be removed any time.
     All code must be marked as deprecated with a link to the bug tracker.
   </description>

--- a/opendj-legacy/pom.xml
+++ b/opendj-legacy/pom.xml
@@ -13,6 +13,7 @@
   ! information: "Portions Copyright [year] [name of copyright owner]".
   !
   ! Copyright 2014-2015 ForgeRock AS.
+  ! Portions Copyright 2017 Wren Security.
   !
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -23,9 +24,9 @@
     <version>3.0.0</version>
   </parent>
   <artifactId>opendj-legacy</artifactId>
-  <name>OpenDJ Legacy</name>
+  <name>WrenDS Legacy</name>
   <description>
-    This module contains OpenDJ legacy code that needs to be kept for compatibility reasons
+    This module contains WrenDS legacy code that needs to be kept for compatibility reasons
     but will never be used again. DO NOT USE THIS CODE AT ALL, it could be removed any time.
     All code must be marked as deprecated with a link to the bug tracker.
   </description>

--- a/opendj-maven-plugin/pom.xml
+++ b/opendj-maven-plugin/pom.xml
@@ -34,9 +34,9 @@
   </parent>
 
   <artifactId>opendj-maven-plugin</artifactId>
-  <name>WrenDS Maven Plugin</name>
+  <name>Wren:DS Maven Plugin</name>
   <description>
-    Set of build tools for WrenDS project.
+    Set of build tools for Wren:DS project.
   </description>
   <packaging>maven-plugin</packaging>
 

--- a/opendj-maven-plugin/pom.xml
+++ b/opendj-maven-plugin/pom.xml
@@ -22,6 +22,7 @@
   ! CDDL HEADER END
   !
   !      Copyright 2015 ForgeRock AS.
+  !      Portions Copyright 2017 Wren Security.
   !
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -33,9 +34,9 @@
   </parent>
 
   <artifactId>opendj-maven-plugin</artifactId>
-  <name>OpenDJ Maven Plugin</name>
+  <name>WrenDS Maven Plugin</name>
   <description>
-    Set of build tools for OpenDJ project.
+    Set of build tools for WrenDS project.
   </description>
   <packaging>maven-plugin</packaging>
 

--- a/opendj-rest2ldap-servlet/pom.xml
+++ b/opendj-rest2ldap-servlet/pom.xml
@@ -25,9 +25,9 @@
   </parent>
 
   <artifactId>opendj-rest2ldap-servlet</artifactId>
-  <name>WrenDS Commons REST LDAP Gateway</name>
+  <name>Wren:DS Commons REST LDAP Gateway</name>
   <description>
-    Provides integration between the WrenDS Commons REST Adapter and Servlet APIs.
+    Provides integration between the Wren:DS Commons REST Adapter and Servlet APIs.
   </description>
   <packaging>war</packaging>
 

--- a/opendj-rest2ldap-servlet/pom.xml
+++ b/opendj-rest2ldap-servlet/pom.xml
@@ -13,6 +13,7 @@
   ! information: "Portions Copyright [year] [name of copyright owner]".
   !
   ! Copyright 2013-2015 ForgeRock AS.
+  ! Portions Copyright 2017 Wren Security.
   !
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -24,9 +25,9 @@
   </parent>
 
   <artifactId>opendj-rest2ldap-servlet</artifactId>
-  <name>OpenDJ Commons REST LDAP Gateway</name>
+  <name>WrenDS Commons REST LDAP Gateway</name>
   <description>
-    Provides integration between the OpenDJ Commons REST Adapter and Servlet APIs.
+    Provides integration between the WrenDS Commons REST Adapter and Servlet APIs.
   </description>
   <packaging>war</packaging>
 

--- a/opendj-server-example-plugin/pom.xml
+++ b/opendj-server-example-plugin/pom.xml
@@ -33,9 +33,9 @@
     <version>3.0.0</version>
   </parent>
   <artifactId>opendj-server-example-plugin</artifactId>
-  <name>WrenDS Server Example Plugin</name>
+  <name>Wren:DS Server Example Plugin</name>
   <description>
-    An example WrenDS Server plugin illustrating how custom components may be developed for WrenDS.
+    An example Wren:DS Server plugin illustrating how custom components may be developed for Wren:DS.
   </description>
   <packaging>jar</packaging>
   <dependencies>

--- a/opendj-server-example-plugin/pom.xml
+++ b/opendj-server-example-plugin/pom.xml
@@ -22,6 +22,7 @@
   ! CDDL HEADER END
   !
   !      Copyright 2014-2015 ForgeRock AS
+  !      Portions Copyright 2017 Wren Security.
   !
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -32,9 +33,9 @@
     <version>3.0.0</version>
   </parent>
   <artifactId>opendj-server-example-plugin</artifactId>
-  <name>OpenDJ Server Example Plugin</name>
+  <name>WrenDS Server Example Plugin</name>
   <description>
-    An example OpenDJ Server plugin illustrating how custom components may be developed for OpenDJ.
+    An example WrenDS Server plugin illustrating how custom components may be developed for WrenDS.
   </description>
   <packaging>jar</packaging>
   <dependencies>

--- a/opendj-server-legacy/pom.xml
+++ b/opendj-server-legacy/pom.xml
@@ -35,9 +35,9 @@
   </parent>
   <artifactId>opendj-server-legacy</artifactId>
   <packaging>jar</packaging>
-  <name>WrenDS</name>
+  <name>Wren:DS</name>
   <description>
-    This module provides the WrenDS server.
+    This module provides the Wren:DS server.
   </description>
   <inceptionYear>2010</inceptionYear>
 
@@ -715,7 +715,7 @@
             </configuration>
           </execution>
 
-          <!-- Create WrenDS manifest -->
+          <!-- Create Wren:DS manifest -->
           <execution>
             <id>opendj-manifest</id>
             <goals>
@@ -833,7 +833,7 @@
             </configuration>
           </execution>
 
-          <!-- Package WrenDS SL4J Logger Adapter jar -->
+          <!-- Package Wren:DS SL4J Logger Adapter jar -->
           <execution>
             <id>build-opendj-slf4j-adapter-jar</id>
             <phase>prepare-package</phase>

--- a/opendj-server-legacy/pom.xml
+++ b/opendj-server-legacy/pom.xml
@@ -22,6 +22,7 @@
   ! CDDL HEADER END
   !
   !      Copyright 2011-2015 ForgeRock AS.
+  !      Portions Copyright 2017 Wren Security.
   !
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -34,9 +35,9 @@
   </parent>
   <artifactId>opendj-server-legacy</artifactId>
   <packaging>jar</packaging>
-  <name>OpenDJ</name>
+  <name>WrenDS</name>
   <description>
-    This module provides the OpenDJ server.
+    This module provides the WrenDS server.
   </description>
   <inceptionYear>2010</inceptionYear>
 
@@ -714,7 +715,7 @@
             </configuration>
           </execution>
 
-          <!-- Create OpenDJ manifest -->
+          <!-- Create WrenDS manifest -->
           <execution>
             <id>opendj-manifest</id>
             <goals>
@@ -832,7 +833,7 @@
             </configuration>
           </execution>
 
-          <!-- Package OpenDJ SL4J Logger Adapter jar -->
+          <!-- Package WrenDS SL4J Logger Adapter jar -->
           <execution>
             <id>build-opendj-slf4j-adapter-jar</id>
             <phase>prepare-package</phase>

--- a/opendj-server/pom.xml
+++ b/opendj-server/pom.xml
@@ -33,9 +33,9 @@
     <version>3.0.0</version>
   </parent>
   <artifactId>opendj-server</artifactId>
-  <name>WrenDS Server</name>
+  <name>Wren:DS Server</name>
   <description>
-    WrenDS LDAP embedded directory server.
+    Wren:DS LDAP embedded directory server.
   </description>
   <packaging>jar</packaging>
   <properties>

--- a/opendj-server/pom.xml
+++ b/opendj-server/pom.xml
@@ -22,6 +22,7 @@
   ! CDDL HEADER END
   !
   !      Copyright 2013-2015 ForgeRock AS
+  !      Portions Copyright 2017 Wren Security.
   !
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -32,9 +33,9 @@
     <version>3.0.0</version>
   </parent>
   <artifactId>opendj-server</artifactId>
-  <name>OpenDJ Server</name>
+  <name>WrenDS Server</name>
   <description>
-    OpenDJ LDAP embedded directory server.
+    WrenDS LDAP embedded directory server.
   </description>
   <packaging>jar</packaging>
   <properties>

--- a/opendj-server/src/test/java/org/forgerock/opendj/server/core/ProductInformationTest.java
+++ b/opendj-server/src/test/java/org/forgerock/opendj/server/core/ProductInformationTest.java
@@ -22,6 +22,7 @@
  *
  *
  *      Copyright 2014 ForgeRock AS.
+ *      Portions Copyright 2017 Wren Security.
  */
 
 package org.forgerock.opendj.server.core;
@@ -47,7 +48,7 @@ public class ProductInformationTest extends ForgeRockTestCase {
 
     @Test
     public void testProductShortName() {
-        assertThat(ProductInformation.getInstance().productShortName()).isEqualTo("OpenDJ");
+        assertThat(ProductInformation.getInstance().productShortName()).isEqualTo("WrenDS");
     }
 
     @Test

--- a/opendj-server/src/test/java/org/forgerock/opendj/server/core/ProductInformationTest.java
+++ b/opendj-server/src/test/java/org/forgerock/opendj/server/core/ProductInformationTest.java
@@ -48,7 +48,7 @@ public class ProductInformationTest extends ForgeRockTestCase {
 
     @Test
     public void testProductShortName() {
-        assertThat(ProductInformation.getInstance().productShortName()).isEqualTo("WrenDS");
+        assertThat(ProductInformation.getInstance().productShortName()).isEqualTo("Wren:DS");
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
   ! CDDL HEADER END
   !
   !      Copyright 2011-2015 ForgeRock AS.
+  !      Portions Copyright 2017 Wren Security.
   !
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -39,59 +40,42 @@
 
     <packaging>pom</packaging>
 
-    <name>OpenDJ Directory Services Project</name>
+    <name>WrenDS Directory Services Project</name>
     <description>
-        OpenDJ is a new LDAPv3 compliant directory service, developed for the Java
-        platform, providing a high performance, highly available and secure store
+        WrenDS is an LDAPv3 compliant directory service, developed for the Java
+        platform, providing a high performance, highly available, secure store
         for the identities managed by enterprises.
     </description>
     <inceptionYear>2011</inceptionYear>
     <url>http://opendj.forgerock.org</url>
 
     <issueManagement>
-        <system>Jira</system>
-        <url>https://bugster.forgerock.org/jira/browse/OPENDJ</url>
+        <system>GitHub Issues</system>
+        <url>https://github.com/WrenSecurity/wrends/issues</url>
     </issueManagement>
 
     <scm>
-        <url>https://stash.forgerock.org/projects/OPENDJ/repos/opendj/browse</url>
-        <connection>scm:git:ssh://git@stash.forgerock.org:7999/opendj/opendj.git</connection>
-        <developerConnection>scm:git:ssh://git@stash.forgerock.org:7999/opendj/opendj.git</developerConnection>
-      <tag>3.0.0</tag>
-  </scm>
-
-    <ciManagement>
-        <system>jenkins</system>
-        <url>https://ci.forgerock.org/view/OpenDJ/job/OpenDJ%20-%20postcommit</url>
-        <notifiers>
-            <notifier>
-                <type>mail</type>
-                <sendOnError>true</sendOnError>
-                <sendOnFailure>true</sendOnFailure>
-                <sendOnSuccess>false</sendOnSuccess>
-                <sendOnWarning>false</sendOnWarning>
-                <address>opendj-dev@forgerock.org</address>
-            </notifier>
-        </notifiers>
-    </ciManagement>
+        <url>https://github.com/WrenSecurity/wrends</url>
+        <connection>scm:git:git://github.com/WrenSecurity/wrends.git</connection>
+        <developerConnection>scm:git:git@github.com:WrenSecurity/wrends.git</developerConnection>
+    </scm>
 
     <repositories>
+        <!-- Needed to retrieve parent POM -->
         <repository>
-            <id>forgerock-staging-repository</id>
-            <name>ForgeRock Release Repository</name>
-            <url>http://maven.forgerock.org/repo/releases</url>
+            <id>wrensecurity-releases</id>
+            <name>Wren Security Release Repository</name>
+            <url>https://wrensecurity.jfrog.io/wrensecurity/releases</url>
+
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>
-        </repository>
-        <repository>
-            <id>forgerock-snapshots-repository</id>
-            <name>ForgeRock Snapshot Repository</name>
-            <url>http://maven.forgerock.org/repo/snapshots</url>
+
             <releases>
-                <enabled>false</enabled>
+                <enabled>true</enabled>
             </releases>
         </repository>
+
         <repository>
             <id>jvnet-nexus-snapshots</id>
             <url>https://maven.java.net/content/repositories/snapshots</url>
@@ -103,6 +87,20 @@
             </snapshots>
         </repository>
     </repositories>
+
+    <distributionManagement>
+        <snapshotRepository>
+            <id>wrensecurity-snapshots</id>
+            <name>Wren Security Snapshot Repository</name>
+            <url>${forgerockDistMgmtSnapshotsUrl}</url>
+        </snapshotRepository>
+
+        <repository>
+            <id>wrensecurity-releases</id>
+            <name>Wren Security Release Repository</name>
+            <url>${forgerockDistMgmtReleasesUrl}</url>
+        </repository>
+    </distributionManagement>
 
     <dependencyManagement>
         <dependencies>
@@ -146,7 +144,7 @@
     </modules>
 
     <properties>
-        <product.name>OpenDJ</product.name>
+        <product.name>WrenDS</product.name>
         <opendj.core.test.jar.version>3.0.0</opendj.core.test.jar.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -40,9 +40,9 @@
 
     <packaging>pom</packaging>
 
-    <name>WrenDS Directory Services Project</name>
+    <name>Wren:DS Directory Services Project</name>
     <description>
-        WrenDS is an LDAPv3 compliant directory service, developed for the Java
+        Wren:DS is an LDAPv3 compliant directory service, developed for the Java
         platform, providing a high performance, highly available, secure store
         for the identities managed by enterprises.
     </description>
@@ -51,13 +51,13 @@
 
     <issueManagement>
         <system>GitHub Issues</system>
-        <url>https://github.com/WrenSecurity/wrends/issues</url>
+        <url>https://github.com/WrenSecurity/WrenDS/issues</url>
     </issueManagement>
 
     <scm>
-        <url>https://github.com/WrenSecurity/wrends</url>
-        <connection>scm:git:git://github.com/WrenSecurity/wrends.git</connection>
-        <developerConnection>scm:git:git@github.com:WrenSecurity/wrends.git</developerConnection>
+        <url>https://github.com/WrenSecurity/WrenDS</url>
+        <connection>scm:git:git://github.com/WrenSecurity/WrenDS.git</connection>
+        <developerConnection>scm:git:git@github.com:WrenSecurity/WrenDS.git</developerConnection>
     </scm>
 
     <repositories>
@@ -144,7 +144,7 @@
     </modules>
 
     <properties>
-        <product.name>WrenDS</product.name>
+        <product.name>Wren:DS</product.name>
         <opendj.core.test.jar.version>3.0.0</opendj.core.test.jar.version>
     </properties>
 


### PR DESCRIPTION
- modifies the OpenDJ / Wren:DS SDK POMs to build using Wren's repos.
- updates branding to call this Wren:DS instead of OpenDJ.
- adds [Wren Deploy](https://github.com/WrenSecurity/wrensec-deploy-tool) RC file.

don't be alarmed about the changes to the "headers" in the test input data for the copyright plug-in -- I am not actually modifying CDDL copyrights. it's source data for the test, since the plugin works with headers.