### PR TITLE
Fix read-only sub-resource CREST API descr (#6)

### DIFF
--- a/opendj-rest2ldap-servlet/src/main/webapp/WEB-INF/classes/rest2ldap/endpoints/api/example-v1.json
+++ b/opendj-rest2ldap-servlet/src/main/webapp/WEB-INF/classes/rest2ldap/endpoints/api/example-v1.json
@@ -21,6 +21,18 @@
                         "dnAttribute": "uid"
                     }
                 },
+                // This resource is the same as "users", but read-only.
+                // Users cannot be created, modified, or deleted through this sub-resource.
+                "read-only-users": {
+                    "type": "collection",
+                    "dnTemplate": "ou=people,dc=example,dc=com",
+                    "resource": "frapi:opendj:rest2ldap:user:1.0",
+                    "namingStrategy": {
+                        "type": "clientDnNaming",
+                        "dnAttribute": "uid"
+                    },
+                    "isReadOnly": true
+                },
                 "groups": {
                     "type": "collection",
                     "dnTemplate": "ou=groups,dc=example,dc=com",

--- a/opendj-rest2ldap/src/main/java/org/forgerock/opendj/rest2ldap/ReadOnlyRequestHandler.java
+++ b/opendj-rest2ldap/src/main/java/org/forgerock/opendj/rest2ldap/ReadOnlyRequestHandler.java
@@ -18,6 +18,8 @@ package org.forgerock.opendj.rest2ldap;
 
 import static org.forgerock.opendj.rest2ldap.Rest2ldapMessages.ERR_READ_ONLY_ENDPOINT;
 
+import org.forgerock.api.models.ApiDescription;
+import org.forgerock.http.ApiProducer;
 import org.forgerock.json.resource.BadRequestException;
 import org.forgerock.json.resource.QueryRequest;
 import org.forgerock.json.resource.QueryResourceHandler;
@@ -28,6 +30,7 @@ import org.forgerock.json.resource.RequestHandler;
 import org.forgerock.json.resource.ResourceException;
 import org.forgerock.json.resource.ResourceResponse;
 import org.forgerock.services.context.Context;
+import org.forgerock.services.descriptor.Describable;
 import org.forgerock.util.promise.Promise;
 
 /**
@@ -55,5 +58,15 @@ final class ReadOnlyRequestHandler extends AbstractRequestHandler {
     @Override
     protected <V> Promise<V, ResourceException> handleRequest(final Context context, final Request request) {
         return new BadRequestException(ERR_READ_ONLY_ENDPOINT.get().toString()).asPromise();
+    }
+
+    @Override
+    public ApiDescription api(ApiProducer<ApiDescription> producer) {
+        if (delegate instanceof Describable) {
+            return ((Describable<ApiDescription, Request>)delegate).api(producer);
+        }
+        else {
+            return super.api(producer);
+        }
     }
 }

--- a/opendj-rest2ldap/src/main/java/org/forgerock/opendj/rest2ldap/Resource.java
+++ b/opendj-rest2ldap/src/main/java/org/forgerock/opendj/rest2ldap/Resource.java
@@ -471,7 +471,7 @@ public final class Resource {
     }
 
     /**
-     * Gets a unique name for the configuration of this resource in CREST.
+     * Gets a unique name for the configuration of this resource as a service in CREST.
      *
      * The name is the combination of the resource type and the writability of the resource. For
      * example, {@code frapi:opendj:rest2ldap:group:1.0:read-write} or

--- a/opendj-rest2ldap/src/main/java/org/forgerock/opendj/rest2ldap/Resource.java
+++ b/opendj-rest2ldap/src/main/java/org/forgerock/opendj/rest2ldap/Resource.java
@@ -470,6 +470,31 @@ public final class Resource {
         return id;
     }
 
+    /**
+     * Gets a unique name for the configuration of this resource in CREST.
+     *
+     * The name is the combination of the resource type and the writability of the resource. For
+     * example, {@code frapi:opendj:rest2ldap:group:1.0:read-write} or
+     * {@code frapi:opendj:rest2ldap:user:1.0:read-only}. Multiple resources can share the same
+     * service description if they manipulate the same resource type and have the same writability.
+     *
+     * @param  isReadOnly
+     *         Whether or not this resource is read-only.
+     *
+     * @return The unique service ID for this resource, given the specified writability.
+     */
+    String getServiceId(boolean isReadOnly) {
+        StringBuilder serviceId = new StringBuilder(this.getResourceId());
+
+        if (isReadOnly) {
+            serviceId.append(":read-only");
+        } else {
+            serviceId.append(":read-write");
+        }
+
+        return serviceId.toString();
+    }
+
     void build(final Rest2Ldap rest2Ldap) {
         // Prevent re-entrant calls.
         if (isBuilt) {
@@ -522,7 +547,7 @@ public final class Resource {
 
         org.forgerock.api.models.Resource.Builder resource = org.forgerock.api.models.Resource.
             resource()
-            .title(id)
+            .title(this.getServiceId(isReadOnly))
             .description(toLS(description))
             .resourceSchema(schemaRef("#/definitions/" + id))
             .mvccSupported(isMvccSupported());
@@ -539,8 +564,8 @@ public final class Resource {
         return ApiDescription.apiDescription()
                       .id("unused").version("unused")
                       .definitions(definitions())
-                      .services(services(resource))
-                      .paths(paths())
+                      .services(services(resource, isReadOnly))
+                      .paths(paths(isReadOnly))
                       .errors(errors())
                       .build();
     }
@@ -555,13 +580,17 @@ public final class Resource {
     ApiDescription collectionApi(boolean isReadOnly) {
         org.forgerock.api.models.Resource.Builder resource = org.forgerock.api.models.Resource.
             resource()
-            .title(id)
+            .title(this.getServiceId(isReadOnly))
             .description(toLS(description))
             .resourceSchema(schemaRef("#/definitions/" + id))
             .mvccSupported(isMvccSupported());
 
         resource.items(buildItems(isReadOnly));
-        resource.create(createOperation(CreateMode.ID_FROM_SERVER));
+
+        if (!isReadOnly) {
+            resource.create(createOperation(CreateMode.ID_FROM_SERVER));
+        }
+
         resource.query(Query.query()
                            .stability(EVOLVING)
                            .type(QueryType.FILTER)
@@ -580,23 +609,29 @@ public final class Resource {
         return ApiDescription.apiDescription()
                              .id("unused").version("unused")
                              .definitions(definitions())
-                             .services(services(resource))
-                             .paths(paths())
+                             .services(services(resource, isReadOnly))
+                             .paths(paths(isReadOnly))
                              .errors(errors())
                              .build();
     }
 
-    private Services services(org.forgerock.api.models.Resource.Builder resource) {
+    private Services services(org.forgerock.api.models.Resource.Builder resource,
+                              boolean isReadOnly) {
+        final String serviceId = this.getServiceId(isReadOnly);
+
         return Services.services()
-                       .put(id, resource.build())
+                       .put(serviceId, resource.build())
                        .build();
     }
 
-    private Paths paths() {
+    private Paths paths(boolean isReadOnly) {
+        final String serviceId = this.getServiceId(isReadOnly);
+        final org.forgerock.api.models.Resource resource = resourceRef("#/services/" + serviceId);
+
         return Paths.paths()
                      // do not put anything in the path to avoid unfortunate string concatenation
                      // also use UNVERSIONED and rely on the router to stamp the version
-                     .put("", versionedPath().put(UNVERSIONED, resourceRef("#/services/" + id)).build())
+                     .put("", versionedPath().put(UNVERSIONED, resource).build())
                      .build();
     }
 

--- a/opendj-server-legacy/resource/config/rest2ldap/endpoints/api/example-v1.json
+++ b/opendj-server-legacy/resource/config/rest2ldap/endpoints/api/example-v1.json
@@ -21,6 +21,18 @@
                         "dnAttribute": "uid"
                     }
                 },
+                // This resource is the same as "users", but read-only.
+                // Users cannot be created, modified, or deleted through this sub-resource.
+                "read-only-users": {
+                    "type": "collection",
+                    "dnTemplate": "ou=people,dc=example,dc=com",
+                    "resource": "frapi:opendj:rest2ldap:user:1.0",
+                    "namingStrategy": {
+                        "type": "clientDnNaming",
+                        "dnAttribute": "uid"
+                    },
+                    "isReadOnly": true
+                },
                 "groups": {
                     "type": "collection",
                     "dnTemplate": "ou=groups,dc=example,dc=com",


### PR DESCRIPTION
Corrects three obscure defects in the Rest2LDAP implementation of CREST descriptors:
- Read-only sub-resources were not appearing at all in the CREST API description JSON.
- When read-only sub-resources appeared in the API description alongside writable sub-resources for the same models, the generated service name for the sub-resources was the same, leading to an IllegalStateException. Now, we generate a unique service name for each sub-resource based on its writability.
- A top-level `create` request was still being rendered in the API description for read-only sub-resources.

Closes #6.