### PR TITLE
Upgrade 4.x for WrenSec repos & Prepare for 4.0.0-M3 Release

### DIFF
--- a/.wren-deploy.rc
+++ b/.wren-deploy.rc
@@ -1,0 +1,1 @@
+export MAVEN_PACKAGE="opendj"

--- a/opendj-bom/pom.xml
+++ b/opendj-bom/pom.xml
@@ -27,7 +27,7 @@
 
     <groupId>org.forgerock.opendj</groupId>
     <artifactId>opendj-bom</artifactId>
-    <version>4.0.0-SNAPSHOT</version>
+    <version>4.0.0-M3</version>
 
     <packaging>pom</packaging>
 

--- a/opendj-bom/pom.xml
+++ b/opendj-bom/pom.xml
@@ -19,9 +19,9 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.forgerock</groupId>
-        <artifactId>forgerock-parent</artifactId>
-        <version>2.0.10</version>
+        <groupId>org.wrensecurity</groupId>
+        <artifactId>wrensec-parent</artifactId>
+        <version>2.2.0</version>
         <relativePath />
     </parent>
 

--- a/opendj-bom/pom.xml
+++ b/opendj-bom/pom.xml
@@ -38,6 +38,7 @@
 
     <properties>
         <i18n-framework.version>1.4.2</i18n-framework.version>
+        <pgpWhitelistArtifact>org.wrensecurity:wrensec-pgp-whitelist:1.3.0</pgpWhitelistArtifact>
     </properties>
 
     <dependencyManagement>

--- a/opendj-bom/pom.xml
+++ b/opendj-bom/pom.xml
@@ -13,6 +13,7 @@
   information: "Portions Copyright [year] [name of copyright owner]".
 
   Copyright 2011-2016 ForgeRock AS.
+  Portions Copyright 2017-2018 Wren Security.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -30,9 +31,9 @@
 
     <packaging>pom</packaging>
 
-    <name>OpenDJ BOM</name>
+    <name>Wren:DS BOM</name>
     <description>
-        Provides a list of OpenDJ dependencies which are known to be compatible with each other.
+        Provides a list of Wren:DS dependencies which are known to be compatible with each other.
     </description>
 
     <properties>
@@ -64,7 +65,7 @@
             </dependency>
 
 
-            <!-- OpenDJ SDK -->
+            <!-- Wren:DS SDK -->
             <dependency>
                 <groupId>org.forgerock.opendj</groupId>
                 <artifactId>opendj-core</artifactId>
@@ -99,31 +100,19 @@
     </dependencyManagement>
 
     <repositories>
+        <!-- Needed to retrieve parent POM -->
         <repository>
-            <id>forgerock-staging-repository</id>
-            <name>ForgeRock Release Repository</name>
-            <url>http://maven.forgerock.org/repo/releases</url>
+            <id>wrensecurity-releases</id>
+            <name>Wren Security Release Repository</name>
+            <url>https://wrensecurity.jfrog.io/wrensecurity/releases</url>
+
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>
-        </repository>
-        <repository>
-            <id>forgerock-snapshots-repository</id>
-            <name>ForgeRock Snapshot Repository</name>
-            <url>http://maven.forgerock.org/repo/snapshots</url>
+
             <releases>
-                <enabled>false</enabled>
-            </releases>
-        </repository>
-        <repository>
-            <id>jvnet-nexus-snapshots</id>
-            <url>https://maven.java.net/content/repositories/snapshots</url>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-            <snapshots>
                 <enabled>true</enabled>
-            </snapshots>
+            </releases>
         </repository>
     </repositories>
 </project>

--- a/opendj-cli/pom.xml
+++ b/opendj-cli/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>opendj-parent</artifactId>
         <groupId>org.forgerock.opendj</groupId>
-        <version>4.0.0-SNAPSHOT</version>
+        <version>4.0.0-M3</version>
     </parent>
 
     <artifactId>opendj-cli</artifactId>

--- a/opendj-cli/pom.xml
+++ b/opendj-cli/pom.xml
@@ -13,6 +13,7 @@
   information: "Portions Copyright [year] [name of copyright owner]".
 
   Copyright 2014-2016 ForgeRock AS.
+  Portions Copyright 2018 Wren Security.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -24,8 +25,10 @@
     </parent>
 
     <artifactId>opendj-cli</artifactId>
-    <name>OpenDJ CLI API</name>
-    <description>This module includes CLI API for implementing CLI applications.</description>
+    <name>Wren:DS CLI API</name>
+    <description>
+        This module includes an API for implementing command-line LDAP directory applications.
+    </description>
 
     <packaging>bundle</packaging>
 

--- a/opendj-config/pom.xml
+++ b/opendj-config/pom.xml
@@ -13,6 +13,7 @@
   information: "Portions Copyright [year] [name of copyright owner]".
 
   Copyright 2013-2016 ForgeRock AS.
+  Portions Copyright 2017-2018 Wren Security.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
@@ -22,7 +23,7 @@
     <version>4.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>opendj-config</artifactId>
-  <name>OpenDJ Configuration API</name>
+  <name>Wren:DS Configuration API</name>
   <description>
     This module includes Configuration APIs for implementing LDAP Directory
     client and server applications.

--- a/opendj-config/pom.xml
+++ b/opendj-config/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.forgerock.opendj</groupId>
     <artifactId>opendj-parent</artifactId>
-    <version>4.0.0-SNAPSHOT</version>
+    <version>4.0.0-M3</version>
   </parent>
   <artifactId>opendj-config</artifactId>
   <name>Wren:DS Configuration API</name>

--- a/opendj-core/pom.xml
+++ b/opendj-core/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>opendj-parent</artifactId>
         <groupId>org.forgerock.opendj</groupId>
-        <version>4.0.0-SNAPSHOT</version>
+        <version>4.0.0-M3</version>
     </parent>
 
     <artifactId>opendj-core</artifactId>

--- a/opendj-core/pom.xml
+++ b/opendj-core/pom.xml
@@ -13,6 +13,7 @@
   information: "Portions Copyright [year] [name of copyright owner]".
 
   Copyright 2011-2016 ForgeRock AS.
+  Portions Copyright 2018 Wren Security.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -24,7 +25,7 @@
     </parent>
 
     <artifactId>opendj-core</artifactId>
-    <name>OpenDJ Core APIs</name>
+    <name>Wren:DS Core APIs</name>
     <description>
         This module provides the core APIs required for implementing LDAP Directory
         client and server applications. Unlike the SDK this module does not
@@ -243,7 +244,7 @@
             <id>forgerock-release</id>
 
             <properties>
-                <javadocTitle>OpenDJ LDAP SDK ${project.version} API</javadocTitle>
+                <javadocTitle>Wren:DS LDAP SDK ${project.version} API</javadocTitle>
                 <timestamp>${maven.build.timestamp}</timestamp>
                 <maven.build.timestamp.format>yyyy</maven.build.timestamp.format>
             </properties>

--- a/opendj-doc-generated-ref/pom.xml
+++ b/opendj-doc-generated-ref/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>opendj-parent</artifactId>
         <groupId>org.forgerock.opendj</groupId>
-        <version>4.0.0-SNAPSHOT</version>
+        <version>4.0.0-M3</version>
     </parent>
 
     <artifactId>opendj-doc-generated-ref</artifactId>

--- a/opendj-doc-generated-ref/pom.xml
+++ b/opendj-doc-generated-ref/pom.xml
@@ -13,6 +13,7 @@
   ~ information: "Portions Copyright [year] [name of copyright owner]".
   ~
   ~ Copyright 2016 ForgeRock AS.
+  ~ Portions Copyright 2018 Wren Security.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -25,7 +26,7 @@
 
     <artifactId>opendj-doc-generated-ref</artifactId>
 
-    <name>OpenDJ Doc Generated References</name>
+    <name>Wren:DS Doc Generated References</name>
     <description>Build generated documentation sources.</description>
     <packaging>pom</packaging>
 
@@ -588,10 +589,9 @@
                                     <goal>build</goal>
                                 </goals>
                                 <configuration>
-                                    <projectName>OpenDJ</projectName>
+                                    <projectName>Wren:DS</projectName>
                                     <projectVersion>${project.version}</projectVersion>
                                     <releaseVersion>${project.version}</releaseVersion>
-                                    <googleAnalyticsId>UA-23412190-8</googleAnalyticsId>
                                     <formats combine.self="override">
                                         <format>man</format>
                                     </formats>

--- a/opendj-doc-maven-plugin/pom.xml
+++ b/opendj-doc-maven-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>opendj-parent</artifactId>
         <groupId>org.forgerock.opendj</groupId>
-        <version>4.0.0-SNAPSHOT</version>
+        <version>4.0.0-M3</version>
     </parent>
 
     <artifactId>opendj-doc-maven-plugin</artifactId>

--- a/opendj-doc-maven-plugin/pom.xml
+++ b/opendj-doc-maven-plugin/pom.xml
@@ -13,6 +13,7 @@
   information: "Portions Copyright [year] [name of copyright owner]".
 
   Copyright 2015-2016 ForgeRock AS.
+  Portions Copyright 2018 Wren Security.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -26,7 +27,7 @@
     <artifactId>opendj-doc-maven-plugin</artifactId>
     <packaging>maven-plugin</packaging>
 
-    <name>OpenDJ Doc Helper Maven Plugin</name>
+    <name>Wren:DS Doc Helper Maven Plugin</name>
     <description>Helps to build generated documentation sources.</description>
 
     <properties>

--- a/opendj-doc-maven-plugin/src/main/java/org/forgerock/opendj/maven/doc/GenerateMessageFileMojo.java
+++ b/opendj-doc-maven-plugin/src/main/java/org/forgerock/opendj/maven/doc/GenerateMessageFileMojo.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2008-2010 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2018 Wren Security.
  */
 package org.forgerock.opendj.maven.doc;
 
@@ -363,7 +364,7 @@ public class GenerateMessageFileMojo extends AbstractMojo {
     private InputStream loadPropertiesFromJar(final String category) throws IOException {
         getLog().debug("category: " + category);
         final JarFile jarFile = new JarFile(
-                Paths.get(project.getBuild().getDirectory(), "opendj", "lib", "opendj.jar").toString());
+                Paths.get(project.getBuild().getDirectory(), "opendj", "lib", "wrends.jar").toString());
         return jarFile.getInputStream(jarFile.getJarEntry(
                 Paths.get("org", "opends", "messages", category + ".properties").toString()));
     }

--- a/opendj-dsml-servlet/pom.xml
+++ b/opendj-dsml-servlet/pom.xml
@@ -13,6 +13,7 @@
   information: "Portions Copyright [year] [name of copyright owner]".
 
   Copyright 2015-2016 ForgeRock AS.
+  Portions Copyright 2017-2018 Wren Security.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -24,8 +25,8 @@
     </parent>
 
     <artifactId>opendj-dsml-servlet</artifactId>
-    <name>OpenDJ DSML Gateway</name>
-    <description>OpenDJ DSML Gateway</description>
+    <name>Wren:DS DSML Gateway</name>
+    <description>Directory Services Mark-up Language Gateway</description>
     <packaging>war</packaging>
 
     <properties>
@@ -60,13 +61,13 @@
             <artifactId>i18n-slf4j</artifactId>
         </dependency>
 
-        <!-- OpenDJ SDK dependency -->
+        <!-- Wren:DS SDK dependency -->
         <dependency>
             <groupId>org.forgerock.opendj</groupId>
             <artifactId>opendj-core</artifactId>
         </dependency>
 
-        <!-- OpenDJ Server dependencies -->
+        <!-- Wren:DS Server dependencies -->
         <dependency>
             <groupId>org.forgerock.opendj</groupId>
             <artifactId>opendj-config</artifactId>
@@ -248,7 +249,7 @@
                 <artifactId>maven-war-plugin</artifactId>
                 <configuration>
                     <webResources>
-                        <!-- Include OpenDJ jars -->
+                        <!-- Include Wren:DS jars -->
                         <resource>
                             <targetPath>WEB-INF/lib</targetPath>
                             <directory>${project.build.directory}/opendj-jars</directory>

--- a/opendj-dsml-servlet/pom.xml
+++ b/opendj-dsml-servlet/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.forgerock.opendj</groupId>
         <artifactId>opendj-parent</artifactId>
-        <version>4.0.0-SNAPSHOT</version>
+        <version>4.0.0-M3</version>
     </parent>
 
     <artifactId>opendj-dsml-servlet</artifactId>

--- a/opendj-embedded-server-examples/pom.xml
+++ b/opendj-embedded-server-examples/pom.xml
@@ -24,8 +24,8 @@
     </parent>
 
     <artifactId>opendj-embedded-server-examples</artifactId>
-    <name>OpenDJ embedded server examples</name>
-    <description>Examples illustrating usage of the OpenDJ embedded server API</description>
+    <name>Wren:DS Embedded Server Examples</name>
+    <description>Examples illustrating usage of the Wren:DS embedded server API</description>
 
     <dependencies>
         <dependency>
@@ -35,14 +35,6 @@
         </dependency>
 
     </dependencies>
-
-    <distributionManagement>
-        <site>
-            <id>forgerock.org</id>
-            <name>OpenDJ Community</name>
-            <url>scp://forgerock.org/var/www/vhosts/opendj.forgerock.org/httpdocs/opendj-embedded-server-examples</url>
-        </site>
-    </distributionManagement>
 
     <build>
         <plugins>

--- a/opendj-embedded-server-examples/pom.xml
+++ b/opendj-embedded-server-examples/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>opendj-parent</artifactId>
         <groupId>org.forgerock.opendj</groupId>
-        <version>4.0.0-SNAPSHOT</version>
+        <version>4.0.0-M3</version>
     </parent>
 
     <artifactId>opendj-embedded-server-examples</artifactId>

--- a/opendj-grizzly/pom.xml
+++ b/opendj-grizzly/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>opendj-parent</artifactId>
         <groupId>org.forgerock.opendj</groupId>
-        <version>4.0.0-SNAPSHOT</version>
+        <version>4.0.0-M3</version>
     </parent>
 
     <artifactId>opendj-grizzly</artifactId>

--- a/opendj-grizzly/pom.xml
+++ b/opendj-grizzly/pom.xml
@@ -13,6 +13,7 @@
   information: "Portions Copyright [year] [name of copyright owner]".
 
   Copyright 2013-2016 ForgeRock AS.
+  Portions Copyright 2018 Wren Security.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -24,8 +25,8 @@
     </parent>
 
     <artifactId>opendj-grizzly</artifactId>
-    <name>OpenDJ Grizzly Transport Provider</name>
-    <description>This module includes a Grizzly based network transport provider for OpenDJ.</description>
+    <name>Wren:DS Grizzly Transport Provider</name>
+    <description>This module includes a Grizzly based network transport provider for Wren:DS.</description>
 
     <packaging>bundle</packaging>
 

--- a/opendj-ldap-sdk-examples/pom.xml
+++ b/opendj-ldap-sdk-examples/pom.xml
@@ -13,6 +13,7 @@
   information: "Portions Copyright [year] [name of copyright owner]".
 
   Copyright 2011-2016 ForgeRock AS.
+  Portions Copyright 2018 Wren Security.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -24,8 +25,8 @@
     </parent>
 
     <artifactId>opendj-ldap-sdk-examples</artifactId>
-    <name>OpenDJ SDK Examples</name>
-    <description>Examples illustrating usage of the OpenDJ LDAP SDK</description>
+    <name>Wren:DS SDK Examples</name>
+    <description>Examples illustrating usage of the Wren:DS LDAP SDK</description>
 
     <dependencies>
         <dependency>
@@ -43,14 +44,6 @@
             <artifactId>slf4j-jdk14</artifactId>
         </dependency>
     </dependencies>
-
-    <distributionManagement>
-        <site>
-            <id>forgerock.org</id>
-            <name>OpenDJ Community</name>
-            <url>scp://forgerock.org/var/www/vhosts/opendj.forgerock.org/httpdocs/opendj-ldap-sdk-examples</url>
-        </site>
-    </distributionManagement>
 
     <build>
         <plugins>

--- a/opendj-ldap-sdk-examples/pom.xml
+++ b/opendj-ldap-sdk-examples/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>opendj-parent</artifactId>
         <groupId>org.forgerock.opendj</groupId>
-        <version>4.0.0-SNAPSHOT</version>
+        <version>4.0.0-M3</version>
     </parent>
 
     <artifactId>opendj-ldap-sdk-examples</artifactId>

--- a/opendj-ldap-toolkit/pom.xml
+++ b/opendj-ldap-toolkit/pom.xml
@@ -13,6 +13,7 @@
   information: "Portions Copyright [year] [name of copyright owner]".
 
   Copyright 2011-2016 ForgeRock AS.
+  Portions Copyright 2018 Wren Security.
  -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -24,8 +25,8 @@
     </parent>
 
     <artifactId>opendj-ldap-toolkit</artifactId>
-    <name>OpenDJ SDK Toolkit</name>
-    <description>This module includes LDAP command line tools based on the OpenDJ LDAP SDK.</description>
+    <name>Wren:DS SDK Toolkit</name>
+    <description>This module includes LDAP command line tools based on the Wren:DS LDAP SDK.</description>
 
     <packaging>jar</packaging>
 

--- a/opendj-ldap-toolkit/pom.xml
+++ b/opendj-ldap-toolkit/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>opendj-parent</artifactId>
         <groupId>org.forgerock.opendj</groupId>
-        <version>4.0.0-SNAPSHOT</version>
+        <version>4.0.0-M3</version>
     </parent>
 
     <artifactId>opendj-ldap-toolkit</artifactId>

--- a/opendj-legacy/pom.xml
+++ b/opendj-legacy/pom.xml
@@ -13,6 +13,7 @@
   information: "Portions Copyright [year] [name of copyright owner]".
 
   Copyright 2014-2016 ForgeRock AS.
+  Portions Copyright 2017-2018 Wren Security.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
@@ -22,9 +23,9 @@
     <version>4.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>opendj-legacy</artifactId>
-  <name>OpenDJ Legacy</name>
+  <name>Wren:DS Legacy</name>
   <description>
-    This module contains OpenDJ legacy code that needs to be kept for compatibility reasons
+    This module contains Wren:DS legacy code that needs to be kept for compatibility reasons
     but will never be used again. DO NOT USE THIS CODE AT ALL, it could be removed any time.
     All code must be marked as deprecated with a link to the bug tracker.
   </description>

--- a/opendj-legacy/pom.xml
+++ b/opendj-legacy/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.forgerock.opendj</groupId>
     <artifactId>opendj-parent</artifactId>
-    <version>4.0.0-SNAPSHOT</version>
+    <version>4.0.0-M3</version>
   </parent>
   <artifactId>opendj-legacy</artifactId>
   <name>Wren:DS Legacy</name>

--- a/opendj-maven-plugin/pom.xml
+++ b/opendj-maven-plugin/pom.xml
@@ -13,6 +13,7 @@
   information: "Portions Copyright [year] [name of copyright owner]".
 
   Copyright 2015-2016 ForgeRock AS.
+  Portions Copyright 2017-2018 Wren Security.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
@@ -23,9 +24,9 @@
   </parent>
 
   <artifactId>opendj-maven-plugin</artifactId>
-  <name>OpenDJ Maven Plugin</name>
+  <name>Wren:DS Maven Plugin</name>
   <description>
-    Set of build tools for OpenDJ project.
+    Set of build tools for Wren:DS project.
   </description>
   <packaging>maven-plugin</packaging>
 

--- a/opendj-maven-plugin/pom.xml
+++ b/opendj-maven-plugin/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.forgerock.opendj</groupId>
     <artifactId>opendj-parent</artifactId>
-    <version>4.0.0-SNAPSHOT</version>
+    <version>4.0.0-M3</version>
   </parent>
 
   <artifactId>opendj-maven-plugin</artifactId>

--- a/opendj-openidm-account-change-notification-handler/pom.xml
+++ b/opendj-openidm-account-change-notification-handler/pom.xml
@@ -13,19 +13,25 @@
   information: "Portions Copyright [year] [name of copyright owner]".
 
   Copyright 2014-2016 ForgeRock AS.
+  Portions Copyright 2018 Wren Security.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
+
   <parent>
     <groupId>org.forgerock.opendj</groupId>
     <artifactId>opendj-parent</artifactId>
     <version>4.0.0-SNAPSHOT</version>
   </parent>
+
   <artifactId>opendj-openidm-account-change-notification-handler</artifactId>
-  <name>OpenDJ account change notification handler for OpenIDM</name>
+  <name>Wren:DS account change notification handler for Wren:IDM</name>
+
   <description>
-    An OpenDJ Server notification handler that notifies account changes to OpenIDM through REST.
+    A handler for notifying Wren:IDM when an account has been updated, allowing Wren:IDM to react to
+    password and profile change events.
     </description>
+
   <packaging>jar</packaging>
   
   <dependencies>
@@ -34,36 +40,43 @@
       <artifactId>opendj-core</artifactId>
       <scope>provided</scope>
     </dependency>
+
     <dependency>
       <groupId>org.forgerock.opendj</groupId>
       <artifactId>opendj-config</artifactId>
       <scope>provided</scope>
     </dependency>
+
     <dependency>
       <groupId>org.forgerock.commons</groupId>
       <artifactId>i18n-slf4j</artifactId>
       <scope>provided</scope>
     </dependency>
+
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <scope>provided</scope>
     </dependency>
+
     <dependency>
       <groupId>org.forgerock.opendj</groupId>
       <artifactId>opendj-server-legacy</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
+
     <dependency>
       <groupId>org.forgerock.commons</groupId>
       <artifactId>json-crypto-core</artifactId>
     </dependency>
+
     <dependency>
       <groupId>org.forgerock.http</groupId>
       <artifactId>chf-http-core</artifactId>
       <scope>provided</scope>
     </dependency>
+
     <dependency>
       <groupId>org.forgerock.http</groupId>
       <artifactId>chf-client-apache-async</artifactId>
@@ -75,14 +88,18 @@
       <plugin>
         <groupId>org.forgerock.commons</groupId>
         <artifactId>i18n-maven-plugin</artifactId>
+
         <executions>
           <execution>
             <phase>generate-sources</phase>
+
             <goals>
               <goal>generate-messages</goal>
             </goals>
+
             <configuration>
               <resourceDirectory>${basedir}/src/main/resources</resourceDirectory>
+
               <messageFiles>
                 <messageFile>org/forgerock/openidm/accountchange/openidm-account-status-notification-handler.properties</messageFile>
               </messageFiles>
@@ -90,16 +107,20 @@
           </execution>
         </executions>
       </plugin>
+
       <plugin>
         <groupId>org.forgerock.opendj</groupId>
         <artifactId>opendj-maven-plugin</artifactId>
+
         <executions>
           <execution>
             <id>generate-config</id>
             <phase>generate-sources</phase>
+
             <goals>
               <goal>generate-config</goal>
             </goals>
+
             <configuration>
               <packageName>org.forgerock.openidm.accountchange</packageName>
               <isExtension>true</isExtension>
@@ -107,6 +128,7 @@
           </execution>
         </executions>
       </plugin>
+
       <!-- Retrieve the SCM revision number and store it into the ${buildRevision} 
         property and retrieve the build timestamp and store it into the ${buildDateTime} 
         property -->
@@ -114,17 +136,22 @@
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>buildnumber-maven-plugin</artifactId>
       </plugin>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
+
         <executions>
           <execution>
             <phase>package</phase>
+
             <goals>
               <goal>shade</goal>
             </goals>
+
             <configuration>
               <createDependencyReducedPom>false</createDependencyReducedPom>
+
               <transformers>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                   <manifestEntries>
@@ -138,18 +165,23 @@
           </execution>
         </executions>
       </plugin>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
+
         <executions>
           <execution>
             <id>make-assembly</id>
             <phase>package</phase>
+
             <goals>
               <goal>single</goal>
             </goals>
+
             <configuration>
               <appendAssemblyId>false</appendAssemblyId>
+
               <descriptors>
                 <descriptor>src/main/assembly/descriptor.xml</descriptor>
               </descriptors>
@@ -165,6 +197,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-project-info-reports-plugin</artifactId>
+
         <reportSets>
           <reportSet>
             <reports>
@@ -173,11 +206,11 @@
           </reportSet>
         </reportSets>
       </plugin>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
       </plugin>
     </plugins>
   </reporting>
-  
 </project>

--- a/opendj-openidm-account-change-notification-handler/pom.xml
+++ b/opendj-openidm-account-change-notification-handler/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.forgerock.opendj</groupId>
     <artifactId>opendj-parent</artifactId>
-    <version>4.0.0-SNAPSHOT</version>
+    <version>4.0.0-M3</version>
   </parent>
 
   <artifactId>opendj-openidm-account-change-notification-handler</artifactId>

--- a/opendj-openidm-account-change-notification-handler/pom.xml
+++ b/opendj-openidm-account-change-notification-handler/pom.xml
@@ -25,12 +25,12 @@
   </parent>
 
   <artifactId>opendj-openidm-account-change-notification-handler</artifactId>
-  <name>Wren:DS account change notification handler for Wren:IDM</name>
+  <name>Wren:DS Account Change Notification Handler for IDM</name>
 
   <description>
     A handler for notifying Wren:IDM when an account has been updated, allowing Wren:IDM to react to
     password and profile change events.
-    </description>
+  </description>
 
   <packaging>jar</packaging>
   

--- a/opendj-packages/opendj-deb/opendj-deb-oem/pom.xml
+++ b/opendj-packages/opendj-deb/opendj-deb-oem/pom.xml
@@ -13,6 +13,7 @@
   information: "Portions Copyright [year] [name of copyright owner]".
 
   Copyright 2015 ForgeRock AS.
+  Portions Copyright 2018 Wren Security.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -24,17 +25,17 @@
     </parent>
 
     <artifactId>opendj-deb-oem</artifactId>
-    <name>OpenDJ Debian OEM Package</name>
+    <name>Wren:DS Debian OEM Package</name>
 
     <description>
-        This module generates an OpenDJ OEM edition debian package.
+        This module generates an Wren:DS OEM edition debian package.
     </description>
 
     <properties>
         <sysv.file.location>${project.parent.parent.basedir}/resources/sysv/opendj</sysv.file.location>
         <deb.product.name>${product.name}-OEM</deb.product.name>
         <deb.product.name.lowercase>${product.name.lowercase}-oem</deb.product.name.lowercase>
-        <deb.product.summary>This OpenDJ package does not include the Berkeley JE Backend and can be redistributed without any additional license</deb.product.summary>
+        <deb.product.summary>This Wren:DS package does not include the Berkeley JE Backend and can be redistributed without any additional license</deb.product.summary>
 
         <!-- We need to hardcode this path because maven ant plugin does not resolve ${project.parent.basedir} -->
         <deb.resources.path>../resources</deb.resources.path>

--- a/opendj-packages/opendj-deb/opendj-deb-oem/pom.xml
+++ b/opendj-packages/opendj-deb/opendj-deb-oem/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.forgerock.opendj</groupId>
         <artifactId>opendj-deb</artifactId>
-        <version>4.0.0-SNAPSHOT</version>
+        <version>4.0.0-M3</version>
     </parent>
 
     <artifactId>opendj-deb-oem</artifactId>

--- a/opendj-packages/opendj-deb/opendj-deb-standard/pom.xml
+++ b/opendj-packages/opendj-deb/opendj-deb-standard/pom.xml
@@ -13,6 +13,7 @@
   information: "Portions Copyright [year] [name of copyright owner]".
 
   Copyright 2015 ForgeRock AS.
+  Portions Copyright 2018 Wren Security.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -24,17 +25,17 @@
     </parent>
 
     <artifactId>opendj-deb-standard</artifactId>
-    <name>OpenDJ Debian Standard Package</name>
+    <name>Wren:DS Debian Standard Package</name>
 
     <description>
-        This module generates an OpenDJ OEM edition debian package.
+        This module generates an Wren:DS OEM edition debian package.
     </description>
 
     <properties>
         <sysv.file.location>${project.parent.parent.basedir}/resources/sysv/opendj</sysv.file.location>
         <deb.product.name>${product.name}</deb.product.name>
         <deb.product.name.lowercase>${product.name.lowercase}</deb.product.name.lowercase>
-        <deb.product.summary>This OpenDJ package includes the Berkeley JE Backend and cannot be redistributed without a suitable license</deb.product.summary>
+        <deb.product.summary>This Wren:DS package includes the Berkeley JE Backend and cannot be redistributed without a suitable license</deb.product.summary>
 
         <!-- We need to hardcode this path because maven ant plugin does not resolve ${project.parent.basedir} -->
         <deb.resources.path>../resources</deb.resources.path>

--- a/opendj-packages/opendj-deb/opendj-deb-standard/pom.xml
+++ b/opendj-packages/opendj-deb/opendj-deb-standard/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.forgerock.opendj</groupId>
         <artifactId>opendj-deb</artifactId>
-        <version>4.0.0-SNAPSHOT</version>
+        <version>4.0.0-M3</version>
     </parent>
 
     <artifactId>opendj-deb-standard</artifactId>

--- a/opendj-packages/opendj-deb/pom.xml
+++ b/opendj-packages/opendj-deb/pom.xml
@@ -13,6 +13,7 @@
   information: "Portions Copyright [year] [name of copyright owner]".
 
   Copyright 2015-2016 ForgeRock AS.
+  Portions Copyright 2018 Wren Security.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -42,10 +43,10 @@
     </profiles>
 
     <artifactId>opendj-deb</artifactId>
-    <name>OpenDJ Debian Packages Parent</name>
+    <name>Wren:DS Debian Packages Parent</name>
 
     <description>
-        This module contains configuration and generic plugin calls to generate Debian OpenDJ packages.
+        This module contains configuration and generic plugin calls to generate Debian Wren:DS packages.
     </description>
 
     <properties>
@@ -164,7 +165,7 @@
                                 <deb>${project.build.directory}/${deb.product.name.lowercase}_${project.version}-${deb.release}_all.deb</deb>
                                 <controlDir>${project.build.directory}/deb/control</controlDir>
                                 <dataSet>
-                                    <!-- OpenDJ service file -->
+                                    <!-- Wren:DS service file -->
                                     <data>
                                         <src>${sysv.file.location}</src>
                                         <type>file</type>
@@ -195,7 +196,7 @@
                                         </mapper>
                                     </data>
 
-                                    <!-- OpenDJ archive documentation files -->
+                                    <!-- Wren:DS archive documentation files -->
                                     <data>
                                         <src>${project.build.directory}/${product.name.lowercase}</src>
                                         <type>directory</type>
@@ -208,7 +209,7 @@
                                         </mapper>
                                     </data>
 
-                                    <!-- OpenDJ man pages -->
+                                    <!-- Wren:DS man pages -->
                                     <data>
                                         <src>${manpage.dir}</src>
                                         <type>directory</type>
@@ -218,7 +219,7 @@
                                         </mapper>
                                     </data>
 
-                                    <!-- OpenDJ archive files without specific permission -->
+                                    <!-- Wren:DS archive files without specific permission -->
                                     <data>
                                         <src>${project.build.directory}/${product.name.lowercase}</src>
                                         <type>directory</type>
@@ -244,7 +245,7 @@
                                         </mapper>
                                     </data>
 
-                                    <!-- OpenDJ archive files with specific permission -->
+                                    <!-- Wren:DS archive files with specific permission -->
                                     <data>
                                         <src>${project.build.directory}/${product.name.lowercase}</src>
                                         <type>directory</type>
@@ -263,7 +264,7 @@
                                         </mapper>
                                     </data>
 
-                                    <!-- OpenDJ archive template folder -->
+                                    <!-- Wren:DS archive template folder -->
                                     <data>
                                         <src>${project.build.directory}/${product.name.lowercase}</src>
                                         <type>directory</type>

--- a/opendj-packages/opendj-deb/pom.xml
+++ b/opendj-packages/opendj-deb/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.forgerock.opendj</groupId>
         <artifactId>opendj-packages</artifactId>
-        <version>4.0.0-SNAPSHOT</version>
+        <version>4.0.0-M3</version>
     </parent>
 
     <profiles>

--- a/opendj-packages/opendj-msi/opendj-msi-standard/pom.xml
+++ b/opendj-packages/opendj-msi/opendj-msi-standard/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.forgerock.opendj</groupId>
         <artifactId>opendj-msi</artifactId>
-        <version>4.0.0-SNAPSHOT</version>
+        <version>4.0.0-M3</version>
     </parent>
 
     <artifactId>opendj-msi-standard</artifactId>

--- a/opendj-packages/opendj-msi/opendj-msi-standard/pom.xml
+++ b/opendj-packages/opendj-msi/opendj-msi-standard/pom.xml
@@ -13,6 +13,7 @@
   information: "Portions Copyright [year] [name of copyright owner]".
 
   Copyright 2015-2016 ForgeRock AS.
+  Portions Copyright 2018 Wren Security.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -24,12 +25,12 @@
     </parent>
 
     <artifactId>opendj-msi-standard</artifactId>
-    <name>OpenDJ MSI Standard Package</name>
+    <name>Wren:DS MSI Standard Package</name>
 
     <packaging>pom</packaging>
 
     <description>
-        This module generates an OpenDJ MSI package.
+        This module generates an Wren:DS MSI package.
     </description>
 
     <properties>

--- a/opendj-packages/opendj-msi/pom.xml
+++ b/opendj-packages/opendj-msi/pom.xml
@@ -13,6 +13,7 @@
   information: "Portions Copyright [year] [name of copyright owner]".
 
   Copyright 2015-2016 ForgeRock AS.
+  Portions Copyright 2018 Wren Security.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -24,12 +25,12 @@
     </parent>
 
     <artifactId>opendj-msi</artifactId>
-    <name>OpenDJ MSI Packages Parent</name>
+    <name>Wren:DS MSI Packages Parent</name>
 
     <packaging>pom</packaging>
 
     <description>
-        This module contains configuration and generic plugin call to build OpenDJ MSI packages.
+        This module contains configuration and generic plugin call to build Wren:DS MSI packages.
     </description>
 
     <profiles>

--- a/opendj-packages/opendj-msi/pom.xml
+++ b/opendj-packages/opendj-msi/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.forgerock.opendj</groupId>
         <artifactId>opendj-packages</artifactId>
-        <version>4.0.0-SNAPSHOT</version>
+        <version>4.0.0-M3</version>
     </parent>
 
     <artifactId>opendj-msi</artifactId>

--- a/opendj-packages/opendj-rpm/opendj-rpm-oem/pom.xml
+++ b/opendj-packages/opendj-rpm/opendj-rpm-oem/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.forgerock.opendj</groupId>
         <artifactId>opendj-rpm</artifactId>
-        <version>4.0.0-SNAPSHOT</version>
+        <version>4.0.0-M3</version>
     </parent>
 
     <artifactId>opendj-rpm-oem</artifactId>

--- a/opendj-packages/opendj-rpm/opendj-rpm-oem/pom.xml
+++ b/opendj-packages/opendj-rpm/opendj-rpm-oem/pom.xml
@@ -13,6 +13,7 @@
   information: "Portions Copyright [year] [name of copyright owner]".
 
   Copyright 2015 ForgeRock AS.
+  Portions Copyright 2018 Wren Security.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -24,10 +25,10 @@
     </parent>
 
     <artifactId>opendj-rpm-oem</artifactId>
-    <name>OpenDJ RPM OEM Package</name>
+    <name>Wren:DS RPM OEM Package</name>
 
     <description>
-        This module generates a rpm package of the OpenDJ OEM edition.
+        This module generates a rpm package of the Wren:DS OEM edition.
     </description>
 
     <properties>
@@ -36,7 +37,7 @@
         <rpm.product.name.lowercase>${product.name.lowercase}-oem</rpm.product.name.lowercase>
         <rpm.resources.path>${project.parent.basedir}/resources</rpm.resources.path>
         <rpm.description.header>${product.name} LDAP Server OEM edition</rpm.description.header>
-        <rpm.product.summary>This OpenDJ package does not include the Berkeley JE Backend and can be redistributed without any additional license</rpm.product.summary>
+        <rpm.product.summary>This Wren:DS package does not include the Berkeley JE Backend and can be redistributed without any additional license</rpm.product.summary>
         <rpm.license>CDDL</rpm.license>
     </properties>
 

--- a/opendj-packages/opendj-rpm/opendj-rpm-standard/pom.xml
+++ b/opendj-packages/opendj-rpm/opendj-rpm-standard/pom.xml
@@ -13,6 +13,7 @@
   information: "Portions Copyright [year] [name of copyright owner]".
 
   Copyright 2015 ForgeRock AS.
+  Portions Copyright 2018 Wren Security.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -24,10 +25,10 @@
     </parent>
 
     <artifactId>opendj-rpm-standard</artifactId>
-    <name>OpenDJ RPM Standard Package</name>
+    <name>Wren:DS RPM Standard Package</name>
 
     <description>
-        This module generates an OpenDJ standard edition rpm package.
+        This module generates an Wren:DS standard edition rpm package.
     </description>
 
     <properties>
@@ -36,7 +37,7 @@
         <rpm.product.name.lowercase>${product.name.lowercase}</rpm.product.name.lowercase>
         <rpm.resources.path>${project.parent.basedir}/resources</rpm.resources.path>
         <rpm.description.header>${product.name} LDAP Server</rpm.description.header>
-        <rpm.product.summary>This OpenDJ package includes the Berkeley JE Backend and cannot be redistributed without a suitable license</rpm.product.summary>
+        <rpm.product.summary>This Wren:DS package includes the Berkeley JE Backend and cannot be redistributed without a suitable license</rpm.product.summary>
         <rpm.license>CDDL, Oracle, France Telecom</rpm.license>
     </properties>
 

--- a/opendj-packages/opendj-rpm/opendj-rpm-standard/pom.xml
+++ b/opendj-packages/opendj-rpm/opendj-rpm-standard/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.forgerock.opendj</groupId>
         <artifactId>opendj-rpm</artifactId>
-        <version>4.0.0-SNAPSHOT</version>
+        <version>4.0.0-M3</version>
     </parent>
 
     <artifactId>opendj-rpm-standard</artifactId>

--- a/opendj-packages/opendj-rpm/pom.xml
+++ b/opendj-packages/opendj-rpm/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.forgerock.opendj</groupId>
         <artifactId>opendj-packages</artifactId>
-        <version>4.0.0-SNAPSHOT</version>
+        <version>4.0.0-M3</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/opendj-packages/opendj-rpm/pom.xml
+++ b/opendj-packages/opendj-rpm/pom.xml
@@ -13,6 +13,7 @@
   information: "Portions Copyright [year] [name of copyright owner]".
 
   Copyright 2015-2016 ForgeRock AS.
+  Portions Copyright 2018 Wren Security.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -26,7 +27,7 @@
     <packaging>pom</packaging>
 
     <artifactId>opendj-rpm</artifactId>
-    <name>OpenDJ RPM Packages Parent</name>
+    <name>Wren:DS RPM Packages Parent</name>
 
     <profiles>
         <profile>
@@ -45,7 +46,7 @@
     </profiles>
 
     <description>
-        This module contains configuration and generic plugin calls to generate RPM OpenDJ packages.
+        This module contains configuration and generic plugin calls to generate RPM Wren:DS packages.
     </description>
 
     <properties>
@@ -139,10 +140,10 @@
                         <targetOS>linux</targetOS>
                         <description>
                             ${rpm.description.header}
-                            OpenDJ is an LDAPv3 compliant directory service, developed for the Java
+                            Wren:DS is an LDAPv3 compliant directory service, developed for the Java
                             platform, providing a high performance, highly available and secure store
                             for the identities managed by enterprises. Its easy installation process,
-                            combined with the power of the Java platform makes OpenDJ one of the
+                            combined with the power of the Java platform makes Wren:DS one of the
                             simplest and fastest directory servers to deploy and manage.
 
                             ${rpm.product.summary}

--- a/opendj-packages/opendj-svr4/opendj-svr4-standard/pom.xml
+++ b/opendj-packages/opendj-svr4/opendj-svr4-standard/pom.xml
@@ -13,6 +13,7 @@
   information: "Portions Copyright [year] [name of copyright owner]".
 
   Copyright 2015 ForgeRock AS.
+  Portions Copyright 2018 Wren Security.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -24,12 +25,12 @@
     </parent>
 
     <artifactId>opendj-svr4-sandard</artifactId>
-    <name>OpenDJ SVR4 Standard Package</name>
+    <name>Wren:DS SVR4 Standard Package</name>
 
     <packaging>pom</packaging>
 
     <description>
-        This module generates a standard SVR4 OpenDJ version.
+        This module generates a standard SVR4 Wren:DS version.
     </description>
 
     <build>

--- a/opendj-packages/opendj-svr4/opendj-svr4-standard/pom.xml
+++ b/opendj-packages/opendj-svr4/opendj-svr4-standard/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.forgerock.opendj</groupId>
         <artifactId>opendj-svr4</artifactId>
-        <version>4.0.0-SNAPSHOT</version>
+        <version>4.0.0-M3</version>
     </parent>
 
     <artifactId>opendj-svr4-sandard</artifactId>

--- a/opendj-packages/opendj-svr4/pom.xml
+++ b/opendj-packages/opendj-svr4/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.forgerock.opendj</groupId>
         <artifactId>opendj-packages</artifactId>
-        <version>4.0.0-SNAPSHOT</version>
+        <version>4.0.0-M3</version>
     </parent>
 
     <artifactId>opendj-svr4</artifactId>

--- a/opendj-packages/opendj-svr4/pom.xml
+++ b/opendj-packages/opendj-svr4/pom.xml
@@ -13,6 +13,7 @@
   information: "Portions Copyright [year] [name of copyright owner]".
 
   Copyright 2015 ForgeRock AS.
+  Portions Copyright 2018 Wren Security.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -24,12 +25,12 @@
     </parent>
 
     <artifactId>opendj-svr4</artifactId>
-    <name>OpenDJ SVR4 Packages Parent</name>
+    <name>Wren:DS SVR4 Packages Parent</name>
 
     <packaging>pom</packaging>
 
     <description>
-        This module contains configuration and generic plugin call to build OpenDJ SVR4 packages.
+        This module contains configuration and generic plugin call to build Wren:DS SVR4 packages.
     </description>
 
     <profiles>

--- a/opendj-packages/opendj-zip/opendj-zip-oem/pom.xml
+++ b/opendj-packages/opendj-zip/opendj-zip-oem/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.forgerock.opendj</groupId>
         <artifactId>opendj-zip</artifactId>
-        <version>4.0.0-SNAPSHOT</version>
+        <version>4.0.0-M3</version>
     </parent>
 
     <artifactId>opendj-zip-oem</artifactId>

--- a/opendj-packages/opendj-zip/opendj-zip-oem/pom.xml
+++ b/opendj-packages/opendj-zip/opendj-zip-oem/pom.xml
@@ -13,6 +13,7 @@
   information: "Portions Copyright [year] [name of copyright owner]".
 
   Copyright 2015-2016 ForgeRock AS.
+  Portions Copyright 2018 Wren Security.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -24,12 +25,12 @@
     </parent>
 
     <artifactId>opendj-zip-oem</artifactId>
-    <name>OpenDJ ZIP OEM Pacakge</name>
+    <name>Wren:DS ZIP OEM Pacakge</name>
 
     <packaging>pom</packaging>
 
     <description>
-        This module generates an OEM OpenDJ version.
+        This module generates an OEM Wren:DS version.
     </description>
 
     <properties>
@@ -156,7 +157,7 @@
             <plugin>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <executions>
-                    <!-- Unpack files from OpenDJ standard archive -->
+                    <!-- Unpack files from Wren:DS standard archive -->
                     <execution>
                         <id>unpack-archive</id>
                         <goals>
@@ -173,7 +174,7 @@
                 </executions>
             </plugin>
 
-            <!-- Creates OpenDJ OEM version archive -->
+            <!-- Creates Wren:DS OEM version archive -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>

--- a/opendj-packages/opendj-zip/pom.xml
+++ b/opendj-packages/opendj-zip/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.forgerock.opendj</groupId>
         <artifactId>opendj-packages</artifactId>
-        <version>4.0.0-SNAPSHOT</version>
+        <version>4.0.0-M3</version>
     </parent>
 
     <artifactId>opendj-zip</artifactId>

--- a/opendj-packages/opendj-zip/pom.xml
+++ b/opendj-packages/opendj-zip/pom.xml
@@ -13,6 +13,7 @@
   information: "Portions Copyright [year] [name of copyright owner]".
 
   Copyright 2015 ForgeRock AS.
+  Portions Copyright 2018 Wren Security.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -24,12 +25,12 @@
     </parent>
 
     <artifactId>opendj-zip</artifactId>
-    <name>OpenDJ ZIP Packages Parent</name>
+    <name>Wren:DS ZIP Packages Parent</name>
 
     <packaging>pom</packaging>
 
     <description>
-        This module contains configuration and generic plugin call to build OpenDJ ZIP packages.
+        This module contains configuration and generic plugin call to build Wren:DS ZIP packages.
     </description>
 
     <profiles>

--- a/opendj-packages/pom.xml
+++ b/opendj-packages/pom.xml
@@ -13,6 +13,7 @@
   information: "Portions Copyright [year] [name of copyright owner]".
 
   Copyright 2015-2016 ForgeRock AS.
+  Portions Copyright 2018 Wren Security.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -24,9 +25,9 @@
     </parent>
 
     <artifactId>opendj-packages</artifactId>
-    <name>OpenDJ Packages</name>
+    <name>Wren:DS Packages</name>
     <description>
-        This module contains sub-modules which generates OEM OpenDJ version, deb and rpm OpenDJ packages.
+        This module contains sub-modules which generates OEM Wren:DS version, deb and rpm Wren:DS packages.
     </description>
 
     <packaging>pom</packaging>
@@ -87,7 +88,7 @@
     <build>
         <pluginManagement>
             <plugins>
-                <!-- Unpack files from OpenDJ standard archive -->
+                <!-- Unpack files from Wren:DS standard archive -->
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-dependency-plugin</artifactId>

--- a/opendj-packages/pom.xml
+++ b/opendj-packages/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.forgerock.opendj</groupId>
         <artifactId>opendj-parent</artifactId>
-        <version>4.0.0-SNAPSHOT</version>
+        <version>4.0.0-M3</version>
     </parent>
 
     <artifactId>opendj-packages</artifactId>

--- a/opendj-rest2ldap-servlet/pom.xml
+++ b/opendj-rest2ldap-servlet/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.forgerock.opendj</groupId>
     <artifactId>opendj-parent</artifactId>
-    <version>4.0.0-SNAPSHOT</version>
+    <version>4.0.0-M3</version>
   </parent>
 
   <artifactId>opendj-rest2ldap-servlet</artifactId>

--- a/opendj-rest2ldap-servlet/pom.xml
+++ b/opendj-rest2ldap-servlet/pom.xml
@@ -13,6 +13,7 @@
   information: "Portions Copyright [year] [name of copyright owner]".
 
   Copyright 2013-2016 ForgeRock AS.
+  Portions Copyright 2017-2018 Wren Security.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
@@ -23,9 +24,9 @@
   </parent>
 
   <artifactId>opendj-rest2ldap-servlet</artifactId>
-  <name>OpenDJ Commons REST LDAP Gateway</name>
+  <name>Wren:DS Commons REST LDAP Gateway</name>
   <description>
-    Provides integration between the OpenDJ Commons REST Adapter and Servlet APIs.
+    Provides integration between the Wren:DS Commons REST Adapter and Servlet APIs.
   </description>
   <packaging>war</packaging>
 

--- a/opendj-rest2ldap/pom.xml
+++ b/opendj-rest2ldap/pom.xml
@@ -23,7 +23,7 @@
         <groupId>org.forgerock.opendj</groupId>
         <version>4.0.0-SNAPSHOT</version>
     </parent>
-	
+
     <artifactId>opendj-rest2ldap</artifactId>
     <name>Wren:DS Commons REST Adapter</name>
     <description>This module includes APIs for accessing LDAP repositories using commons REST.</description>

--- a/opendj-rest2ldap/pom.xml
+++ b/opendj-rest2ldap/pom.xml
@@ -67,6 +67,14 @@
         <dependency>
             <groupId>org.forgerock.http</groupId>
             <artifactId>chf-oauth2</artifactId>
+            <!--
+              NOTE: This is a workaround for the missing openIG Toolkit 4.5.2.
+                    In OpenDS 4.x, FR moved this dependency to a separate
+                    project that we have in wrensec-commons. So, for 3.5.x,
+                    we're using it instead of the copy from OpenIG we don't
+                    have.
+              -->
+            <version>21.0.0-alpha-6</version>
         </dependency>
 
         <dependency>

--- a/opendj-rest2ldap/pom.xml
+++ b/opendj-rest2ldap/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>opendj-parent</artifactId>
         <groupId>org.forgerock.opendj</groupId>
-        <version>4.0.0-SNAPSHOT</version>
+        <version>4.0.0-M3</version>
     </parent>
 
     <artifactId>opendj-rest2ldap</artifactId>

--- a/opendj-rest2ldap/pom.xml
+++ b/opendj-rest2ldap/pom.xml
@@ -13,6 +13,7 @@
    information: "Portions Copyright [year] [name of copyright owner]".
 
    Copyright 2012-2016 ForgeRock AS.
+   Portions Copyright 2018 Wren Security.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -24,7 +25,7 @@
     </parent>
 	
     <artifactId>opendj-rest2ldap</artifactId>
-    <name>OpenDJ Commons REST Adapter</name>
+    <name>Wren:DS Commons REST Adapter</name>
     <description>This module includes APIs for accessing LDAP repositories using commons REST.</description>
 
     <packaging>bundle</packaging>

--- a/opendj-server-example-plugin/pom.xml
+++ b/opendj-server-example-plugin/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.forgerock.opendj</groupId>
     <artifactId>opendj-parent</artifactId>
-    <version>4.0.0-SNAPSHOT</version>
+    <version>4.0.0-M3</version>
   </parent>
   <artifactId>opendj-server-example-plugin</artifactId>
   <name>Wren:DS Server Example Plugin</name>

--- a/opendj-server-example-plugin/pom.xml
+++ b/opendj-server-example-plugin/pom.xml
@@ -13,6 +13,7 @@
   information: "Portions Copyright [year] [name of copyright owner]".
 
   Copyright 2014-2016 ForgeRock AS.
+  Portions Copyright 2017-2018 Wren Security.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
@@ -22,9 +23,9 @@
     <version>4.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>opendj-server-example-plugin</artifactId>
-  <name>OpenDJ Server Example Plugin</name>
+  <name>Wren:DS Server Example Plugin</name>
   <description>
-    An example OpenDJ Server plugin illustrating how custom components may be developed for OpenDJ.
+    An example Wren:DS Server plugin illustrating how custom components may be developed for Wren:DS.
   </description>
   <packaging>jar</packaging>
   <dependencies>

--- a/opendj-server-legacy/pom.xml
+++ b/opendj-server-legacy/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.forgerock.opendj</groupId>
     <artifactId>opendj-parent</artifactId>
-    <version>4.0.0-SNAPSHOT</version>
+    <version>4.0.0-M3</version>
   </parent>
   <artifactId>opendj-server-legacy</artifactId>
   <packaging>jar</packaging>

--- a/opendj-server-legacy/pom.xml
+++ b/opendj-server-legacy/pom.xml
@@ -13,6 +13,7 @@
   information: "Portions Copyright [year] [name of copyright owner]".
 
   Copyright 2011-2016 ForgeRock AS.
+  Portions Copyright 2017-2018 Wren Security.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
@@ -24,9 +25,9 @@
   </parent>
   <artifactId>opendj-server-legacy</artifactId>
   <packaging>jar</packaging>
-  <name>OpenDJ Server</name>
+  <name>Wren:DS Server</name>
   <description>
-    This module provides the OpenDJ LDAP Directory Server.
+    This module provides the Wren:DS LDAP Directory Server.
   </description>
   <inceptionYear>2010</inceptionYear>
 
@@ -682,7 +683,7 @@
             </configuration>
           </execution>
 
-          <!-- Create OpenDJ manifest -->
+          <!-- Create Wren:DS manifest -->
           <execution>
             <id>opendj-manifest</id>
             <goals>
@@ -805,7 +806,7 @@
             </configuration>
           </execution>
 
-          <!-- Package OpenDJ SL4J Logger Adapter jar -->
+          <!-- Package Wren:DS SL4J Logger Adapter jar -->
           <execution>
             <id>build-opendj-slf4j-adapter-jar</id>
             <phase>prepare-package</phase>

--- a/opendj-server/pom.xml
+++ b/opendj-server/pom.xml
@@ -13,6 +13,7 @@
   information: "Portions Copyright [year] [name of copyright owner]".
 
   Copyright 2013-2016 ForgeRock AS.
+  Portions Copyright 2017-2018 Wren Security.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
@@ -22,9 +23,9 @@
     <version>4.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>opendj-server</artifactId>
-  <name>OpenDJ Server NG</name>
+  <name>Wren:DS Server NG</name>
   <description>
-    OpenDJ LDAP embedded directory server.
+    Wren:DS LDAP embedded directory server.
   </description>
   <packaging>jar</packaging>
   <properties>

--- a/opendj-server/pom.xml
+++ b/opendj-server/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.forgerock.opendj</groupId>
     <artifactId>opendj-parent</artifactId>
-    <version>4.0.0-SNAPSHOT</version>
+    <version>4.0.0-M3</version>
   </parent>
   <artifactId>opendj-server</artifactId>
   <name>Wren:DS Server NG</name>

--- a/opendj-server/src/test/java/org/forgerock/opendj/server/core/ProductInformationTest.java
+++ b/opendj-server/src/test/java/org/forgerock/opendj/server/core/ProductInformationTest.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2014 ForgeRock AS.
+ * Portions Copyright 2017-2018 Wren Security.
  */
 
 package org.forgerock.opendj.server.core;
@@ -37,7 +38,7 @@ public class ProductInformationTest extends ForgeRockTestCase {
 
     @Test
     public void testProductShortName() {
-        assertThat(ProductInformation.getInstance().productShortName()).isEqualTo("OpenDJ");
+        assertThat(ProductInformation.getInstance().productShortName()).isEqualTo("Wren:DS");
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,7 @@
   information: "Portions Copyright [year] [name of copyright owner]".
 
   Copyright 2011-2016 ForgeRock AS.
+  Portions Copyright 2017-2018 Wren Security.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -28,22 +29,18 @@
 
     <packaging>pom</packaging>
 
-    <name>OpenDJ Directory Services Project</name>
+    <name>Wren:DS Directory Services Project</name>
     <description>
-        OpenDJ is a new LDAPv3 compliant directory service, developed for the Java
-        platform, providing a high performance, highly available and secure store
+        Wren:DS is an LDAPv3 compliant directory service, developed for the Java
+        platform, providing a high performance, highly available, secure store
         for the identities managed by enterprises.
     </description>
 
     <properties>
-        <product.name>OpenDJ</product.name>
-        <product.name.lowercase>opendj</product.name.lowercase>
+        <product.name>Wren:DS</product.name>
+        <product.name.lowercase>wrends</product.name.lowercase>
         <product.locales>ca_ES,es,de,fr,ja,ko,pl,zh_CN,zh_TW</product.locales>
         <localized.jars.classifier>i18n</localized.jars.classifier>
-
-        <site.distribution.url>
-            scp://community.internal.forgerock.com/var/www/vhosts/opendj.forgerock.org/httpdocs
-        </site.distribution.url>
 
         <forgerock-build-tools.version>1.0.2</forgerock-build-tools.version>
         <forgerock-doc-plugin.version>3.2.2-SNAPSHOT</forgerock-doc-plugin.version>
@@ -54,7 +51,7 @@
         <!-- OSGi bundles properties -->
         <opendj.osgi.import.additional />
         <!--
-         | Use provide:=true to disallow mixing OpenDJ and ForgeRock resource versions.
+         | Use provide:=true to disallow mixing Wren:DS and ForgeRock resource versions.
          | it change the version policy from == + to == =+  [2.0,3) [2.0,2.1)
         -->
         <opendj.osgi.import>
@@ -69,24 +66,16 @@
         <checkstyleVersion>5.5</checkstyleVersion>
     </properties>
 
-    <inceptionYear>2011</inceptionYear>
-    <url>http://opendj.forgerock.org</url>
+    <inceptionYear>2017</inceptionYear>
+    <url>http://wrensecurity.org/</url>
 
     <mailingLists>
         <mailingList>
-            <name>OpenDJ Users Mailing List</name>
-            <archive>http://lists.forgerock.org/pipermail/opendj/</archive>
-            <subscribe>https://lists.forgerock.org/mailman/listinfo/opendj/</subscribe>
-            <unsubscribe>https://lists.forgerock.org/mailman/listinfo/opendj/</unsubscribe>
-            <post>opendj@forgerock.org</post>
-        </mailingList>
-
-        <mailingList>
-            <name>OpenDJ Developers Mailing List</name>
-            <archive>http://lists.forgerock.org/pipermail/opendj-dev/</archive>
-            <subscribe>https://lists.forgerock.org/mailman/listinfo/opendj-dev/</subscribe>
-            <unsubscribe>https://lists.forgerock.org/mailman/listinfo/opendj-dev/</unsubscribe>
-            <post>opendj-dev@forgerock.org</post>
+            <name>Wren Security Mailing List</name>
+            <archive>https://groups.google.com/forum/#!forum/wren-security</archive>
+            <subscribe>https://groups.google.com/forum/#!forum/wren-security</subscribe>
+            <unsubscribe>https://groups.google.com/forum/#!forum/wren-security</unsubscribe>
+            <post>wren-security@googlegroups.com</post>
         </mailingList>
     </mailingLists>
 
@@ -95,7 +84,7 @@
             <name>CDDL-1.0</name>
             <url>http://www.opensource.org/licenses/CDDL-1.0</url>
             <comments>Common Development and Distribution License (CDDL) 1.0.
-                This license applies to OpenDJ source code as indicated in the
+                This license applies to Wren:DS source code as indicated in the
                 source files.
             </comments>
             <distribution>repo</distribution>
@@ -103,39 +92,28 @@
     </licenses>
 
     <issueManagement>
-        <system>Jira</system>
-        <url>https://bugster.forgerock.org/jira/browse/OPENDJ</url>
+        <system>GitHub Issues</system>
+        <url>https://github.com/WrenSecurity/WrenDS/issues</url>
     </issueManagement>
 
     <scm>
-        <url>https://stash.forgerock.org/projects/OPENDJ/repos/opendj/browse</url>
-        <connection>scm:git:ssh://git@stash.forgerock.org:7999/opendj/opendj.git</connection>
-        <developerConnection>scm:git:ssh://git@stash.forgerock.org:7999/opendj/opendj.git</developerConnection>
-        <tag>HEAD</tag>
+        <url>https://github.com/WrenSecurity/WrenDS</url>
+        <connection>scm:git:git://github.com/WrenSecurity/WrenDS.git</connection>
+        <developerConnection>scm:git:git@github.com:WrenSecurity/WrenDS.git</developerConnection>
     </scm>
 
-    <distributionManagement>
-        <site>
-            <id>forgerock.org</id>
-            <name>OpenDJ Community</name>
-            <url>${site.distribution.url}</url>
-        </site>
-    </distributionManagement>
-
-    <ciManagement>
-        <system>jenkins</system>
-        <url>https://ci.forgerock.org/view/OpenDJ/job/OpenDJ%20-%20postcommit</url>
-        <notifiers>
-            <notifier>
-                <type>mail</type>
-                <sendOnError>true</sendOnError>
-                <sendOnFailure>true</sendOnFailure>
-                <sendOnSuccess>false</sendOnSuccess>
-                <sendOnWarning>false</sendOnWarning>
-                <address>opendj-dev@forgerock.org</address>
-            </notifier>
-        </notifiers>
-    </ciManagement>
+    <repositories>
+        <repository>
+            <id>jvnet-nexus-snapshots</id>
+            <url>https://maven.java.net/content/repositories/snapshots</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
 
     <dependencyManagement>
         <dependencies>
@@ -154,7 +132,7 @@
                 <scope>test</scope>
             </dependency>
 
-            <!-- OpenDJ SDK -->
+            <!-- Wren:DS SDK -->
             <dependency>
                 <groupId>org.forgerock.opendj</groupId>
                 <artifactId>opendj-core</artifactId>
@@ -415,10 +393,9 @@
                     <artifactId>forgerock-doc-maven-plugin</artifactId>
                     <version>${forgerock-doc-plugin.version}</version>
                     <configuration>
-                        <projectName>OpenDJ</projectName>
+                        <projectName>Wren:DS</projectName>
                         <projectVersion>${project.version}</projectVersion>
                         <releaseVersion>${project.version}</releaseVersion>
-                        <googleAnalyticsId>UA-23412190-8</googleAnalyticsId>
                     </configuration>
                 </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.forgerock.opendj</groupId>
         <artifactId>opendj-bom</artifactId>
-        <version>4.0.0-SNAPSHOT</version>
+        <version>4.0.0-M3</version>
         <relativePath>opendj-bom/pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
This is not the same as what FR had in the OpenDJ 4.0.0-M3 release, but it does contain some parts of it.

This is needed to unblock AM 14.x `master` builds.