### PR TITLE
[3.0] Remove the ForgeRock commercial binary license

### DIFF
--- a/opendj-dsml-servlet/pom.xml
+++ b/opendj-dsml-servlet/pom.xml
@@ -39,11 +39,6 @@
     <description>Wren:DS DSML Gateway</description>
     <packaging>war</packaging>
 
-    <properties>
-       <!-- Folder to store the ForgeRock binary license. The license url could be specified with the option -Dbinary.license.url on the maven command line -->
-       <include.binary.license>${project.basedir}/legal-notices/</include.binary.license>
-    </properties>
-
     <dependencies>
         <!-- ForgeRock libraries -->
         <dependency>

--- a/opendj-rest2ldap-servlet/pom.xml
+++ b/opendj-rest2ldap-servlet/pom.xml
@@ -32,9 +32,6 @@
   <packaging>war</packaging>
 
   <properties>
-    <!-- When released, with the 'binary.license.url' property set,
-         this artifact will contain an additional binary license -->
-    <include.binary.license>${project.build.directory}/${project.build.finalName}/WEB-INF/legal-notices</include.binary.license>
     <checkstyleHeaderLocation>org/forgerock/checkstyle/default-java-header</checkstyleHeaderLocation>
   </properties>
 

--- a/opendj-server-legacy/pom.xml
+++ b/opendj-server-legacy/pom.xml
@@ -76,9 +76,6 @@
     <!-- Could be removed once migration to new config framework will be done-->
     <old.config.files.path>${project.build.directory}/config/admin/defn/org/opends/server/admin/std</old.config.files.path>
 
-    <!-- If we release this project, we need to include the Forgerock binary license -->
-    <include.binary.license>${project.build.directory}/legal-notices/</include.binary.license>
-
     <!-- Additional OSGI import package for this module -->
     <opendj.osgi.import.additional>
       org.forgerock.opendj.*;provide:=true,


### PR DESCRIPTION
This is no longer necessary in our project. Everything falls under the CDDL.

This is related to #33 .