### PR TITLE
[3.0] Correct ZIP Packages to Use Raw Product Name

### DIFF
--- a/opendj-dsml-servlet/pom.xml
+++ b/opendj-dsml-servlet/pom.xml
@@ -22,7 +22,7 @@
   ! CDDL HEADER END
   !
   !      Copyright 2015 ForgeRock AS.
-  !      Portions Copyright 2017 Wren Security.
+  !      Portions Copyright 2017-2019 Wren Security.
   !
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -219,7 +219,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
                 <configuration>
-                    <warName>${product.name}-${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}-DSML</warName>
+                    <warName>${product.lowercaseName}-${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}-DSML</warName>
                     <webResources>
                         <!-- Include CDDLv1_0.txt -->
                         <resource>

--- a/opendj-server-legacy/pom.xml
+++ b/opendj-server-legacy/pom.xml
@@ -22,7 +22,7 @@
   ! CDDL HEADER END
   !
   !      Copyright 2011-2015 ForgeRock AS.
-  !      Portions Copyright 2017 Wren Security.
+  !      Portions Copyright 2017-2019 Wren Security.
   !
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -61,7 +61,6 @@
     <jars.dir>${project.build.directory}/jars</jars.dir>
 
     <!-- Product information properties -->
-    <lowerCaseProductName>opendj</lowerCaseProductName>
     <patchFixIds />
     <isDebugBuild>false</isDebugBuild>
     <docHomepageUrl>http://opendj.forgerock.org/</docHomepageUrl>
@@ -327,7 +326,7 @@
           <artifactId>maven-jar-plugin</artifactId>
           <configuration>
             <outputDirectory>${jars.dir}</outputDirectory>
-            <finalName>${product.name}</finalName>
+            <finalName>${product.lowercaseName}</finalName>
             <archive>
               <addMavenDescriptor>false</addMavenDescriptor>
               <index>true</index>
@@ -531,7 +530,7 @@
             </goals>
             <configuration>
               <classPathProperty>classpath.bootstrap</classPathProperty>
-              <productJarName>${product.name}</productJarName>
+              <productJarName>${product.lowercaseName}</productJarName>
               <supportedLocales>${locales}</supportedLocales>
               <excludes>
                 <exclude>org.slf4j:slf4j-jdk14</exclude>
@@ -549,7 +548,7 @@
             </goals>
             <configuration>
               <classPathProperty>classpath.bootstrap-client</classPathProperty>
-              <productJarName>${product.name}</productJarName>
+              <productJarName>${product.lowercaseName}</productJarName>
               <supportedLocales>${locales}</supportedLocales>
               <additionalJars>
                  <additionalJar>opendj-je-backend.jar</additionalJar>
@@ -1046,7 +1045,7 @@
               <goal>single</goal>
             </goals>
             <configuration>
-              <finalName>${lowerCaseProductName}</finalName>
+              <finalName>${product.lowercaseName}</finalName>
               <outputDirectory>${project.build.directory}/package</outputDirectory>
               <appendAssemblyId>false</appendAssemblyId>
               <attach>false</attach>
@@ -1127,14 +1126,14 @@
             </goals>
             <configuration>
               <target>
-                <zip destfile="${project.build.directory}/package/${product.name}-${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}.zip">
-                  <zipfileset dir="${project.build.directory}/package/${lowerCaseProductName}" includes="**/*" excludes="bin/*,template/**/*,lib/_client-script.sh,lib/_script-util.sh,lib/_server-script.sh,lib/_mixed-script.sh,setup,uninstall,upgrade,QuickSetup.app/Contents/MacOS/universalJavaApplicationStub,Uninstall.app/Contents/MacOS/universalJavaApplicationStub,bin/ControlPanel.app/Contents/MacOS/universalJavaApplicationStub" filemode="644" dirmode="755" prefix="opendj" />
-                  <zipfileset dir="${project.build.directory}/package/${lowerCaseProductName}" includes="lib/_client-script.sh,lib/_script-util.sh,lib/_server-script.sh,lib/_mixed-script.sh" filemode="755" dirmode="755" prefix="opendj" />
-                  <zipfileset dir="${project.build.directory}/package/${lowerCaseProductName}" includes="bin/*" filemode="755" dirmode="755" prefix="opendj" />
-                  <zipfileset dir="${project.build.directory}/package/${lowerCaseProductName}" includes="setup,uninstall,upgrade,QuickSetup.app/Contents/MacOS/universalJavaApplicationStub,Uninstall.app/Contents/MacOS/universalJavaApplicationStub,bin/ControlPanel.app/Contents/MacOS/universalJavaApplicationStub" filemode="755" dirmode="755" prefix="opendj" />
-                  <zipfileset dir="${project.build.directory}/package/${lowerCaseProductName}" includes="template/**/*" filemode="444" dirmode="744" prefix="opendj" />
+                <zip destfile="${project.build.directory}/package/${product.lowercaseName}-${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}.zip">
+                  <zipfileset dir="${project.build.directory}/package/${product.lowercaseName}" includes="**/*" excludes="bin/*,template/**/*,lib/_client-script.sh,lib/_script-util.sh,lib/_server-script.sh,lib/_mixed-script.sh,setup,uninstall,upgrade,QuickSetup.app/Contents/MacOS/universalJavaApplicationStub,Uninstall.app/Contents/MacOS/universalJavaApplicationStub,bin/ControlPanel.app/Contents/MacOS/universalJavaApplicationStub" filemode="644" dirmode="755" prefix="opendj" />
+                  <zipfileset dir="${project.build.directory}/package/${product.lowercaseName}" includes="lib/_client-script.sh,lib/_script-util.sh,lib/_server-script.sh,lib/_mixed-script.sh" filemode="755" dirmode="755" prefix="opendj" />
+                  <zipfileset dir="${project.build.directory}/package/${product.lowercaseName}" includes="bin/*" filemode="755" dirmode="755" prefix="opendj" />
+                  <zipfileset dir="${project.build.directory}/package/${product.lowercaseName}" includes="setup,uninstall,upgrade,QuickSetup.app/Contents/MacOS/universalJavaApplicationStub,Uninstall.app/Contents/MacOS/universalJavaApplicationStub,bin/ControlPanel.app/Contents/MacOS/universalJavaApplicationStub" filemode="755" dirmode="755" prefix="opendj" />
+                  <zipfileset dir="${project.build.directory}/package/${product.lowercaseName}" includes="template/**/*" filemode="444" dirmode="744" prefix="opendj" />
                 </zip>
-                <attachartifact file="${project.build.directory}/package/${product.name}-${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}.zip" type="zip" />
+                <attachartifact file="${project.build.directory}/package/${product.lowercaseName}-${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}.zip" type="zip" />
               </target>
             </configuration>
           </execution>
@@ -1481,7 +1480,7 @@
                 </goals>
                 <configuration>
                   <outputDirectory>${project.build.directory}/package</outputDirectory>
-                  <finalName>${lowerCaseProductName}</finalName>
+                  <finalName>${product.lowercaseName}</finalName>
                   <descriptors>
                     <descriptor>src/main/assembly/opendj-snmp-archive-assembly.xml</descriptor>
                   </descriptors>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
   ! CDDL HEADER END
   !
   !      Copyright 2011-2015 ForgeRock AS.
-  !      Portions Copyright 2017 Wren Security.
+  !      Portions Copyright 2017-2019 Wren Security.
   !
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -145,6 +145,7 @@
 
     <properties>
         <product.name>Wren:DS</product.name>
+        <product.lowercaseName>wrends</product.lowercaseName>
         <opendj.core.test.jar.version>3.0.0</opendj.core.test.jar.version>
     </properties>
 


### PR DESCRIPTION
the default behavior for DS 3.x was to use the human-friendly product name to name JAR and ZIP files. FR corrected this in 3.5.1 and 4.x, but we didn't have this in 3.x. I've corrected the issue by introducing a lower-cased version of the name for these files.

NOTE: `product.name` is used internally in the DS build as the name of the product that DS matches upon connection. if the property and all POM references to it are renamed, then DS won't build.

Closes #12.