### PR TITLE
Fix builds on Java 11 and above

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [8]
+        java: [8, 11, 17]
     name: "Java ${{ matrix.java }} build"
     steps:
       - uses: actions/checkout@v2

--- a/opendj-core/src/test/java/org/forgerock/opendj/ldap/ByteSequenceTestCase.java
+++ b/opendj-core/src/test/java/org/forgerock/opendj/ldap/ByteSequenceTestCase.java
@@ -13,13 +13,13 @@
  *
  * Copyright 2010 Sun Microsystems, Inc.
  * Portions copyright 2014 ForgeRock AS.
+ * Portions copyright 2022 Wren Security.
  */
 package org.forgerock.opendj.ldap;
 
 import java.io.ByteArrayOutputStream;
 import java.util.Arrays;
-
-import javax.xml.bind.DatatypeConverter;
+import java.util.Base64;
 
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -153,8 +153,8 @@ public abstract class ByteSequenceTestCase extends SdkTestCase {
     }
 
     @Test(dataProvider = "byteSequenceProvider")
-    public void testToBase64String(final ByteSequence bs, final byte[] ba) throws Exception {
+    public void testToBase64String(final ByteSequence bs, final byte[] ba) {
         final String base64 = bs.toBase64String();
-        Assert.assertEquals(base64, DatatypeConverter.printBase64Binary(ba));
+        Assert.assertEquals(base64, new String(Base64.getEncoder().encode(ba)));
     }
 }

--- a/opendj-core/src/test/java/org/forgerock/opendj/ldap/ByteStringTestCase.java
+++ b/opendj-core/src/test/java/org/forgerock/opendj/ldap/ByteStringTestCase.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2010 Sun Microsystems, Inc.
  * Portions copyright 2011-2016 ForgeRock AS.
+ * Portions copyright 2022 Wren Security.
  */
 package org.forgerock.opendj.ldap;
 
@@ -22,8 +23,7 @@ import java.nio.charset.Charset;
 import java.nio.charset.CharsetDecoder;
 import java.util.Arrays;
 
-import javax.xml.bind.DatatypeConverter;
-
+import com.google.common.io.BaseEncoding;
 import org.forgerock.i18n.LocalizedIllegalArgumentException;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
@@ -247,8 +247,8 @@ public class ByteStringTestCase extends ByteSequenceTestCase {
     }
 
     @Test(dataProvider = "validBase64Data")
-    public void testValueOfBase64(final String hexData, final String encodedData) throws Exception {
-        final byte[] data = DatatypeConverter.parseHexBinary(hexData);
+    public void testValueOfBase64(final String hexData, final String encodedData) {
+        final byte[] data = BaseEncoding.base16().lowerCase().decode(hexData);
         final byte[] decodedData = ByteString.valueOfBase64(encodedData).toByteArray();
         Assert.assertEquals(decodedData, data);
     }

--- a/opendj-grizzly/src/test/java/org/forgerock/opendj/grizzly/GrizzlyLDAPListenerTestCase.java
+++ b/opendj-grizzly/src/test/java/org/forgerock/opendj/grizzly/GrizzlyLDAPListenerTestCase.java
@@ -718,6 +718,7 @@ public class GrizzlyLDAPListenerTestCase extends SdkTestCase {
             final Connection failedConnection =
                     new LDAPConnectionFactory(listenerAddr.getHostName(),
                         listenerAddr.getPort()).getConnection();
+            failedConnection.bind("cn=test", "password".toCharArray());
             failedConnection.close();
             connection.close();
             fail("Connection attempt to closed listener succeeded unexpectedly");


### PR DESCRIPTION
The opendj-core module uses a few classes from JAXB that is not a part of JDK since version 11.

This PR replaces those classes to fix build with Java 11 and newer.

There is also a fix of randomly failing test `testServerDisconnect` from opendj-grizzly module. The test was sometimes failing with message "Connection attempt to closed listener succeeded unexpectedly".

Related fix in OIP's OpenDJ: https://www.github.com/OpenIdentityPlatform/OpenDJ/commit/196abeeef0660082c2053dc7d475f240eca741bc