### PR TITLE
Disable XML processing limits correctly

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,4 +22,4 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
       - name: Run the Maven verify phase
-        run: mvn -B verify -Dclirr.skip -Djdk.xml.xpathExprOpLimit=0 --file pom.xml
+        run: mvn -B verify -Dclirr.skip

--- a/opendj-maven-plugin/src/main/java/org/forgerock/opendj/maven/GenerateConfigMojo.java
+++ b/opendj-maven-plugin/src/main/java/org/forgerock/opendj/maven/GenerateConfigMojo.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2013-2016 ForgeRock AS.
+ * Portions copyright 2022 Wren Security.
  */
 package org.forgerock.opendj.maven;
 
@@ -395,6 +396,9 @@ public final class GenerateConfigMojo extends AbstractMojo {
     private void initializeStylesheets() throws TransformerConfigurationException {
         getLog().info("Loading XSLT stylesheets...");
         stylesheetFactory = TransformerFactory.newInstance();
+        stylesheetFactory.setAttribute("jdk.xml.xpathExprGrpLimit", "0");
+        stylesheetFactory.setAttribute("jdk.xml.xpathExprOpLimit", "0");
+        stylesheetFactory.setAttribute("jdk.xml.xpathTotalOpLimit", "0");
         stylesheetFactory.setURIResolver(resolver);
         stylesheetMetaJava = loadStylesheet("metaMO.xsl");
         stylesheetMetaPackageInfo = loadStylesheet("package-info.xsl");


### PR DESCRIPTION
The XPath limits came with JDK 8u331: https://www.oracle.com/java/technologies/javase/8u331-relnotes.html#JDK-8270504