### PR TITLE
Upgrade dependencies

### DIFF
--- a/opendj-bom/pom.xml
+++ b/opendj-bom/pom.xml
@@ -75,14 +75,6 @@
 
     <dependencyManagement>
         <dependencies>
-            <!-- ForgeRock BOM -->
-            <dependency>
-                <groupId>org.forgerock.commons</groupId>
-                <artifactId>commons-bom</artifactId>
-                <version>22.1.0-SNAPSHOT</version>
-                <scope>import</scope>
-                <type>pom</type>
-            </dependency>
             <!-- Wren Security BOM -->
             <dependency>
                 <groupId>org.wrensecurity.commons</groupId>

--- a/opendj-bom/pom.xml
+++ b/opendj-bom/pom.xml
@@ -69,7 +69,7 @@
     </repositories>
 
     <properties>
-        <i18n-framework.version>1.4.2</i18n-framework.version>
+        <wrensec-commons.version>22.3.0</wrensec-commons.version>
         <pgpWhitelistArtifact>org.wrensecurity:wrensec-pgp-whitelist:1.5.5</pgpWhitelistArtifact>
     </properties>
 
@@ -83,20 +83,21 @@
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
+            <!-- Wren Security BOM -->
+            <dependency>
+                <groupId>org.wrensecurity.commons</groupId>
+                <artifactId>commons-bom</artifactId>
+                <version>${wrensec-commons.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
 
             <!-- I18N framework -->
             <dependency>
-                <groupId>org.forgerock.commons</groupId>
-                <artifactId>i18n-core</artifactId>
-                <version>${i18n-framework.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.forgerock.commons</groupId>
+                <groupId>org.wrensecurity.commons</groupId>
                 <artifactId>i18n-slf4j</artifactId>
-                <version>${i18n-framework.version}</version>
+                <version>${wrensec-commons.version}</version>
             </dependency>
-
 
             <!-- Wren:DS SDK -->
             <dependency>

--- a/opendj-bom/pom.xml
+++ b/opendj-bom/pom.xml
@@ -70,7 +70,7 @@
 
     <properties>
         <wrensec-commons.version>22.3.0</wrensec-commons.version>
-        <pgpWhitelistArtifact>org.wrensecurity:wrensec-pgp-whitelist:1.5.5</pgpWhitelistArtifact>
+        <pgpWhitelistArtifact>org.wrensecurity:wrensec-pgp-whitelist:1.6.0</pgpWhitelistArtifact>
     </properties>
 
     <dependencyManagement>

--- a/opendj-bom/pom.xml
+++ b/opendj-bom/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wrensecurity</groupId>
         <artifactId>wrensec-parent</artifactId>
-        <version>3.3.0</version>
+        <version>3.4.0</version>
         <relativePath />
     </parent>
 

--- a/opendj-cli/pom.xml
+++ b/opendj-cli/pom.xml
@@ -44,7 +44,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.forgerock.commons</groupId>
+            <groupId>org.wrensecurity.commons</groupId>
             <artifactId>i18n-core</artifactId>
         </dependency>
 
@@ -73,7 +73,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.forgerock.commons</groupId>
+                <groupId>org.wrensecurity.commons</groupId>
                 <artifactId>i18n-maven-plugin</artifactId>
                 <executions>
                     <execution>

--- a/opendj-config/pom.xml
+++ b/opendj-config/pom.xml
@@ -30,11 +30,11 @@
   </description>
   <dependencies>
     <dependency>
-      <groupId>org.forgerock.commons</groupId>
+      <groupId>org.wrensecurity.commons</groupId>
       <artifactId>i18n-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.forgerock.commons</groupId>
+      <groupId>org.wrensecurity.commons</groupId>
       <artifactId>i18n-slf4j</artifactId>
     </dependency>
     <dependency>
@@ -121,7 +121,7 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.forgerock.commons</groupId>
+        <groupId>org.wrensecurity.commons</groupId>
         <artifactId>i18n-maven-plugin</artifactId>
         <executions>
           <execution>

--- a/opendj-config/src/test/java/org/forgerock/opendj/config/server/ConstraintTest.java
+++ b/opendj-config/src/test/java/org/forgerock/opendj/config/server/ConstraintTest.java
@@ -13,12 +13,13 @@
  *
  * Copyright 2008 Sun Microsystems, Inc.
  * Portions copyright 2015-2016 ForgeRock AS.
+ * Portions Copyright 2022 Wren Security
  */
 package org.forgerock.opendj.config.server;
 
 import static org.fest.assertions.Assertions.assertThat;
 import static org.forgerock.opendj.ldap.TestCaseUtils.failWasExpected;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 
 import java.io.IOException;

--- a/opendj-config/src/test/java/org/forgerock/opendj/config/server/DefaultBehaviorTest.java
+++ b/opendj-config/src/test/java/org/forgerock/opendj/config/server/DefaultBehaviorTest.java
@@ -13,12 +13,13 @@
  *
  * Copyright 2008 Sun Microsystems, Inc.
  * Portions copyright 2015-2016 ForgeRock AS.
+ * Portions Copyright 2022 Wren Security
  */
 package org.forgerock.opendj.config.server;
 
 import static org.fest.assertions.Assertions.assertThat;
 import static org.forgerock.opendj.ldif.LDIF.makeEntry;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 
 import java.io.IOException;

--- a/opendj-config/src/test/java/org/forgerock/opendj/config/server/ListenerTest.java
+++ b/opendj-config/src/test/java/org/forgerock/opendj/config/server/ListenerTest.java
@@ -13,14 +13,15 @@
  *
  * Copyright 2007-2008 Sun Microsystems, Inc.
  * Portions Copyright 2016 ForgeRock AS.
+ * Portions Copyright 2022 Wren Security
  */
 package org.forgerock.opendj.config.server;
 
 import static org.fest.assertions.Assertions.assertThat;
 import static org.forgerock.opendj.ldif.LDIF.makeEntry;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Matchers.isA;
-import static org.mockito.Matchers.same;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;

--- a/opendj-core/pom.xml
+++ b/opendj-core/pom.xml
@@ -34,7 +34,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.forgerock.commons</groupId>
+            <groupId>org.wrensecurity.commons</groupId>
             <artifactId>i18n-core</artifactId>
         </dependency>
 
@@ -61,7 +61,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.forgerock.commons</groupId>
+            <groupId>org.wrensecurity.commons</groupId>
             <artifactId>i18n-slf4j</artifactId>
         </dependency>
 
@@ -89,7 +89,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.forgerock.commons</groupId>
+                <groupId>org.wrensecurity.commons</groupId>
                 <artifactId>i18n-maven-plugin</artifactId>
                 <executions>
                     <execution>

--- a/opendj-core/pom.xml
+++ b/opendj-core/pom.xml
@@ -44,7 +44,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.forgerock.commons</groupId>
+            <groupId>org.wrensecurity.commons</groupId>
             <artifactId>forgerock-util</artifactId>
         </dependency>
 

--- a/opendj-core/src/test/java/org/forgerock/opendj/ldap/ConnectionPoolTestCase.java
+++ b/opendj-core/src/test/java/org/forgerock/opendj/ldap/ConnectionPoolTestCase.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2010 Sun Microsystems, Inc.
  * Portions Copyright 2011-2015 ForgeRock AS.
+ * Portions Copyright 2022 Wren Security
  */
 
 package org.forgerock.opendj.ldap;
@@ -31,8 +32,8 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
@@ -169,9 +170,9 @@ public class ConnectionPoolTestCase extends SdkTestCase {
         final ConnectionFactory factory = mockConnectionFactory(connection1, connection2);
         final ConnectionPool pool = Connections.newFixedConnectionPool(factory, 2);
 
-        verifyZeroInteractions(factory);
-        verifyZeroInteractions(connection1);
-        verifyZeroInteractions(connection2);
+        verifyNoInteractions(factory);
+        verifyNoInteractions(connection1);
+        verifyNoInteractions(connection2);
 
         /*
          * Obtain connections and verify that the correct underlying connection
@@ -183,7 +184,7 @@ public class ConnectionPoolTestCase extends SdkTestCase {
         assertThat(pc1.bind(bind1).getResultCode()).isEqualTo(ResultCode.SUCCESS);
         verify(factory, times(1)).getConnection();
         verify(connection1).bind(bind1);
-        verifyZeroInteractions(connection2);
+        verifyNoInteractions(connection2);
 
         final Connection pc2 = pool.getConnection();
         assertThat(pc2.bind(bind2).getResultCode()).isEqualTo(ResultCode.SUCCESS);

--- a/opendj-core/src/test/java/org/forgerock/opendj/ldap/ConnectionsTestCase.java
+++ b/opendj-core/src/test/java/org/forgerock/opendj/ldap/ConnectionsTestCase.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2013-2016 ForgeRock AS.
+ * Portions Copyright 2022 Wren Security
  */
 package org.forgerock.opendj.ldap;
 
@@ -20,7 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.forgerock.opendj.ldap.Connections.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import org.forgerock.opendj.ldap.Connections.LeastRequestsDispatcher;
@@ -54,7 +55,7 @@ public class ConnectionsTestCase extends SdkTestCase {
         final Connection connection = mock(Connection.class);
         final Connection uncloseable = Connections.uncloseable(connection);
         uncloseable.close();
-        verifyZeroInteractions(connection);
+        verifyNoInteractions(connection);
     }
 
     @Test
@@ -70,7 +71,7 @@ public class ConnectionsTestCase extends SdkTestCase {
         final Connection connection = mock(Connection.class);
         final Connection uncloseable = Connections.uncloseable(connection);
         uncloseable.close(null, null);
-        verifyZeroInteractions(connection);
+        verifyNoInteractions(connection);
     }
 
     @Test

--- a/opendj-core/src/test/java/org/forgerock/opendj/ldap/ConsistentHashDistributionLoadBalancerTest.java
+++ b/opendj-core/src/test/java/org/forgerock/opendj/ldap/ConsistentHashDistributionLoadBalancerTest.java
@@ -148,7 +148,7 @@ public class ConsistentHashDistributionLoadBalancerTest extends SdkTestCase {
             assertThat(connection).isNotNull();
             connection.close();
         }
-        verifyZeroInteractions(partition1, partition2);
+        verifyNoInteractions(partition1, partition2);
     }
 
     @Test
@@ -157,7 +157,7 @@ public class ConsistentHashDistributionLoadBalancerTest extends SdkTestCase {
             assertThat(connection).isNotNull();
             connection.close();
         }
-        verifyZeroInteractions(partition1, partition2);
+        verifyNoInteractions(partition1, partition2);
     }
 
     @DataProvider
@@ -182,7 +182,7 @@ public class ConsistentHashDistributionLoadBalancerTest extends SdkTestCase {
         verify(hitPartition(isSecondPartition)).addAsync(any(AddRequest.class), any());
         verify(hashFunction).apply(partitionDN.toNormalizedUrlSafeString());
         verify(hitPartition(isSecondPartition)).close();
-        verifyZeroInteractions(missPartition(isSecondPartition));
+        verifyNoInteractions(missPartition(isSecondPartition));
     }
 
     @Test(dataProvider = "requests")
@@ -196,7 +196,7 @@ public class ConsistentHashDistributionLoadBalancerTest extends SdkTestCase {
                                                           any());
         verify(hashFunction).apply(partitionDN.toNormalizedUrlSafeString());
         verify(hitPartition(isSecondPartition)).close();
-        verifyZeroInteractions(missPartition(isSecondPartition));
+        verifyNoInteractions(missPartition(isSecondPartition));
     }
 
     @Test(dataProvider = "requests")
@@ -210,7 +210,7 @@ public class ConsistentHashDistributionLoadBalancerTest extends SdkTestCase {
                                                              any());
         verify(hashFunction).apply(partitionDN.toNormalizedUrlSafeString());
         verify(hitPartition(isSecondPartition)).close();
-        verifyZeroInteractions(missPartition(isSecondPartition));
+        verifyNoInteractions(missPartition(isSecondPartition));
     }
 
     @Test(dataProvider = "requests")
@@ -224,7 +224,7 @@ public class ConsistentHashDistributionLoadBalancerTest extends SdkTestCase {
                                                             any());
         verify(hashFunction).apply(partitionDN.toNormalizedUrlSafeString());
         verify(hitPartition(isSecondPartition)).close();
-        verifyZeroInteractions(missPartition(isSecondPartition));
+        verifyNoInteractions(missPartition(isSecondPartition));
     }
 
     @Test(dataProvider = "requests")
@@ -238,7 +238,7 @@ public class ConsistentHashDistributionLoadBalancerTest extends SdkTestCase {
                                                                      any());
         verify(hashFunction).apply(partitionDN.toNormalizedUrlSafeString());
         verify(hitPartition(isSecondPartition)).close();
-        verifyZeroInteractions(missPartition(isSecondPartition));
+        verifyNoInteractions(missPartition(isSecondPartition));
     }
 
     @Test(dataProvider = "requests")
@@ -252,7 +252,7 @@ public class ConsistentHashDistributionLoadBalancerTest extends SdkTestCase {
                                                             any());
         verify(hashFunction).apply(partitionDN.toNormalizedUrlSafeString());
         verify(hitPartition(isSecondPartition)).close();
-        verifyZeroInteractions(missPartition(isSecondPartition));
+        verifyNoInteractions(missPartition(isSecondPartition));
     }
 
     @Test(dataProvider = "requests")
@@ -266,7 +266,7 @@ public class ConsistentHashDistributionLoadBalancerTest extends SdkTestCase {
                                                               any());
         verify(hashFunction, atLeastOnce()).apply(partitionDN.toNormalizedUrlSafeString());
         verify(hitPartition(isSecondPartition)).close();
-        verifyZeroInteractions(missPartition(isSecondPartition));
+        verifyNoInteractions(missPartition(isSecondPartition));
     }
 
     @Test(dataProvider = "requests")
@@ -282,7 +282,7 @@ public class ConsistentHashDistributionLoadBalancerTest extends SdkTestCase {
                                                             any(SearchResultHandler.class));
         verify(hashFunction).apply(partitionDN.toNormalizedUrlSafeString());
         verify(hitPartition(isSecondPartition)).close();
-        verifyZeroInteractions(missPartition(isSecondPartition));
+        verifyNoInteractions(missPartition(isSecondPartition));
     }
 
     @Test
@@ -356,7 +356,7 @@ public class ConsistentHashDistributionLoadBalancerTest extends SdkTestCase {
                                            any(SearchResultHandler.class));
         verify(hashFunction).apply(dn.toNormalizedUrlSafeString());
         verify(partition1Conn).close();
-        verifyZeroInteractions(partition2Conn);
+        verifyNoInteractions(partition2Conn);
     }
 
     private void verifySearchAgainstAllPartitions(final DN dn, final SearchScope scope) throws Exception {

--- a/opendj-core/src/test/java/org/forgerock/opendj/ldap/ConsistentHashMapTest.java
+++ b/opendj-core/src/test/java/org/forgerock/opendj/ldap/ConsistentHashMapTest.java
@@ -12,11 +12,12 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions Copyright 2022 Wren Security
  */
 package org.forgerock.opendj.ldap;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/opendj-core/src/test/java/org/forgerock/opendj/ldap/RequestLoadBalancerTestCase.java
+++ b/opendj-core/src/test/java/org/forgerock/opendj/ldap/RequestLoadBalancerTestCase.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2016 ForgeRock AS.
  * Portions Copyright 2021 Wren Security.
+ * Portions Copyright 2022 Wren Security
  */
 package org.forgerock.opendj.ldap;
 
@@ -34,7 +35,7 @@ import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
@@ -77,9 +78,9 @@ public class RequestLoadBalancerTestCase extends SdkTestCase {
         configureAllFactoriesOnline();
         try (Connection connection = loadBalancer.getConnection()) {
             assertThat(connection).isNotNull();
-            verifyZeroInteractions(factory1, factory2, factory3);
+            verifyNoInteractions(factory1, factory2, factory3);
         }
-        verifyZeroInteractions(factory1, factory2, factory3);
+        verifyNoInteractions(factory1, factory2, factory3);
         loadBalancer.close();
     }
 
@@ -108,9 +109,9 @@ public class RequestLoadBalancerTestCase extends SdkTestCase {
         configureAllFactoriesOnline();
         try (Connection connection = loadBalancer.getConnectionAsync().get()) {
             assertThat(connection).isNotNull();
-            verifyZeroInteractions(factory1, factory2, factory3);
+            verifyNoInteractions(factory1, factory2, factory3);
         }
-        verifyZeroInteractions(factory1, factory2, factory3);
+        verifyNoInteractions(factory1, factory2, factory3);
     }
 
     @Test
@@ -148,7 +149,7 @@ public class RequestLoadBalancerTestCase extends SdkTestCase {
             connection.addConnectionEventListener(listener);
             connection.removeConnectionEventListener(listener);
         }
-        verifyZeroInteractions(listener);
+        verifyNoInteractions(listener);
     }
 
     @Test
@@ -192,7 +193,7 @@ public class RequestLoadBalancerTestCase extends SdkTestCase {
         try (Connection connection = loadBalancer.getConnectionAsync().get()) {
             connection.abandonAsync(mock(AbandonRequest.class));
         }
-        verifyZeroInteractions(factory1, factory2, factory3);
+        verifyNoInteractions(factory1, factory2, factory3);
     }
 
     // We can't use a DataProviders here because the mocks will be re-initialized for each test method call.
@@ -224,7 +225,7 @@ public class RequestLoadBalancerTestCase extends SdkTestCase {
         verify(expectedFactory).getConnectionAsync();
         verify(expectedConnection).addAsync(same(addRequest), isNull());
         verify(expectedConnection).close();
-        verifyZeroInteractionsForRemainingFactories(expectedFactory);
+        verifyNoInteractionsForRemainingFactories(expectedFactory);
     }
 
     @Test
@@ -250,8 +251,8 @@ public class RequestLoadBalancerTestCase extends SdkTestCase {
         verify(factory3).getConnectionAsync();
         verify(connection3).addAsync(same(addRequest), isNull());
         verify(connection3).close();
-        verifyZeroInteractions(connection1);
-        verifyZeroInteractions(connection2);
+        verifyNoInteractions(connection1);
+        verifyNoInteractions(connection2);
     }
 
     @Test
@@ -267,9 +268,9 @@ public class RequestLoadBalancerTestCase extends SdkTestCase {
         verify(factory1, atLeastOnce()).getConnectionAsync();
         verify(factory2, atLeastOnce()).getConnectionAsync();
         verify(factory3, atLeastOnce()).getConnectionAsync();
-        verifyZeroInteractions(connection1);
-        verifyZeroInteractions(connection2);
-        verifyZeroInteractions(connection3);
+        verifyNoInteractions(connection1);
+        verifyNoInteractions(connection2);
+        verifyNoInteractions(connection3);
     }
 
     // ################## Bind Requests ####################
@@ -299,7 +300,7 @@ public class RequestLoadBalancerTestCase extends SdkTestCase {
         verify(expectedFactory).getConnectionAsync();
         verify(expectedConnection).bindAsync(same(bindRequest), isNull());
         verify(expectedConnection).close();
-        verifyZeroInteractionsForRemainingFactories(expectedFactory);
+        verifyNoInteractionsForRemainingFactories(expectedFactory);
     }
 
     @Test
@@ -325,8 +326,8 @@ public class RequestLoadBalancerTestCase extends SdkTestCase {
         verify(factory3).getConnectionAsync();
         verify(connection3).bindAsync(same(bindRequest), isNull());
         verify(connection3).close();
-        verifyZeroInteractions(connection1);
-        verifyZeroInteractions(connection2);
+        verifyNoInteractions(connection1);
+        verifyNoInteractions(connection2);
     }
 
     @Test
@@ -342,9 +343,9 @@ public class RequestLoadBalancerTestCase extends SdkTestCase {
         verify(factory1, atLeastOnce()).getConnectionAsync();
         verify(factory2, atLeastOnce()).getConnectionAsync();
         verify(factory3, atLeastOnce()).getConnectionAsync();
-        verifyZeroInteractions(connection1);
-        verifyZeroInteractions(connection2);
-        verifyZeroInteractions(connection3);
+        verifyNoInteractions(connection1);
+        verifyNoInteractions(connection2);
+        verifyNoInteractions(connection3);
     }
 
     // ################## Compare Requests ####################
@@ -374,7 +375,7 @@ public class RequestLoadBalancerTestCase extends SdkTestCase {
         verify(expectedFactory).getConnectionAsync();
         verify(expectedConnection).compareAsync(same(compareRequest), isNull());
         verify(expectedConnection).close();
-        verifyZeroInteractionsForRemainingFactories(expectedFactory);
+        verifyNoInteractionsForRemainingFactories(expectedFactory);
     }
 
     @Test
@@ -400,8 +401,8 @@ public class RequestLoadBalancerTestCase extends SdkTestCase {
         verify(factory3).getConnectionAsync();
         verify(connection3).compareAsync(same(compareRequest), isNull());
         verify(connection3).close();
-        verifyZeroInteractions(connection1);
-        verifyZeroInteractions(connection2);
+        verifyNoInteractions(connection1);
+        verifyNoInteractions(connection2);
     }
 
     @Test
@@ -417,9 +418,9 @@ public class RequestLoadBalancerTestCase extends SdkTestCase {
         verify(factory1, atLeastOnce()).getConnectionAsync();
         verify(factory2, atLeastOnce()).getConnectionAsync();
         verify(factory3, atLeastOnce()).getConnectionAsync();
-        verifyZeroInteractions(connection1);
-        verifyZeroInteractions(connection2);
-        verifyZeroInteractions(connection3);
+        verifyNoInteractions(connection1);
+        verifyNoInteractions(connection2);
+        verifyNoInteractions(connection3);
     }
 
     // ################## Delete Requests ####################
@@ -449,7 +450,7 @@ public class RequestLoadBalancerTestCase extends SdkTestCase {
         verify(expectedFactory).getConnectionAsync();
         verify(expectedConnection).deleteAsync(same(deleteRequest), isNull());
         verify(expectedConnection).close();
-        verifyZeroInteractionsForRemainingFactories(expectedFactory);
+        verifyNoInteractionsForRemainingFactories(expectedFactory);
     }
 
     @Test
@@ -475,8 +476,8 @@ public class RequestLoadBalancerTestCase extends SdkTestCase {
         verify(factory3).getConnectionAsync();
         verify(connection3).deleteAsync(same(deleteRequest), isNull());
         verify(connection3).close();
-        verifyZeroInteractions(connection1);
-        verifyZeroInteractions(connection2);
+        verifyNoInteractions(connection1);
+        verifyNoInteractions(connection2);
     }
 
     @Test
@@ -492,9 +493,9 @@ public class RequestLoadBalancerTestCase extends SdkTestCase {
         verify(factory1, atLeastOnce()).getConnectionAsync();
         verify(factory2, atLeastOnce()).getConnectionAsync();
         verify(factory3, atLeastOnce()).getConnectionAsync();
-        verifyZeroInteractions(connection1);
-        verifyZeroInteractions(connection2);
-        verifyZeroInteractions(connection3);
+        verifyNoInteractions(connection1);
+        verifyNoInteractions(connection2);
+        verifyNoInteractions(connection3);
     }
 
     // ################## Extended Requests ####################
@@ -525,7 +526,7 @@ public class RequestLoadBalancerTestCase extends SdkTestCase {
         verify(expectedConnection).extendedRequestAsync(same(extendedRequest),
                                                         isNull());
         verify(expectedConnection).close();
-        verifyZeroInteractionsForRemainingFactories(expectedFactory);
+        verifyNoInteractionsForRemainingFactories(expectedFactory);
     }
 
     @Test
@@ -552,8 +553,8 @@ public class RequestLoadBalancerTestCase extends SdkTestCase {
         verify(factory3).getConnectionAsync();
         verify(connection3).extendedRequestAsync(same(extendedRequest), isNull());
         verify(connection3).close();
-        verifyZeroInteractions(connection1);
-        verifyZeroInteractions(connection2);
+        verifyNoInteractions(connection1);
+        verifyNoInteractions(connection2);
     }
 
     @Test
@@ -569,9 +570,9 @@ public class RequestLoadBalancerTestCase extends SdkTestCase {
         verify(factory1, atLeastOnce()).getConnectionAsync();
         verify(factory2, atLeastOnce()).getConnectionAsync();
         verify(factory3, atLeastOnce()).getConnectionAsync();
-        verifyZeroInteractions(connection1);
-        verifyZeroInteractions(connection2);
-        verifyZeroInteractions(connection3);
+        verifyNoInteractions(connection1);
+        verifyNoInteractions(connection2);
+        verifyNoInteractions(connection3);
     }
 
     // ################## Modify Requests ####################
@@ -601,7 +602,7 @@ public class RequestLoadBalancerTestCase extends SdkTestCase {
         verify(expectedFactory).getConnectionAsync();
         verify(expectedConnection).modifyAsync(same(modifyRequest), isNull());
         verify(expectedConnection).close();
-        verifyZeroInteractionsForRemainingFactories(expectedFactory);
+        verifyNoInteractionsForRemainingFactories(expectedFactory);
     }
 
     @Test
@@ -627,8 +628,8 @@ public class RequestLoadBalancerTestCase extends SdkTestCase {
         verify(factory3).getConnectionAsync();
         verify(connection3).modifyAsync(same(modifyRequest), isNull());
         verify(connection3).close();
-        verifyZeroInteractions(connection1);
-        verifyZeroInteractions(connection2);
+        verifyNoInteractions(connection1);
+        verifyNoInteractions(connection2);
     }
 
     @Test
@@ -644,9 +645,9 @@ public class RequestLoadBalancerTestCase extends SdkTestCase {
         verify(factory1, atLeastOnce()).getConnectionAsync();
         verify(factory2, atLeastOnce()).getConnectionAsync();
         verify(factory3, atLeastOnce()).getConnectionAsync();
-        verifyZeroInteractions(connection1);
-        verifyZeroInteractions(connection2);
-        verifyZeroInteractions(connection3);
+        verifyNoInteractions(connection1);
+        verifyNoInteractions(connection2);
+        verifyNoInteractions(connection3);
     }
 
     // ################## ModifyDN Requests ####################
@@ -676,7 +677,7 @@ public class RequestLoadBalancerTestCase extends SdkTestCase {
         verify(expectedFactory).getConnectionAsync();
         verify(expectedConnection).modifyDNAsync(same(modifyDNRequest), isNull());
         verify(expectedConnection).close();
-        verifyZeroInteractionsForRemainingFactories(expectedFactory);
+        verifyNoInteractionsForRemainingFactories(expectedFactory);
     }
 
     @Test
@@ -703,8 +704,8 @@ public class RequestLoadBalancerTestCase extends SdkTestCase {
         verify(factory3).getConnectionAsync();
         verify(connection3).modifyDNAsync(same(modifyDNRequest), isNull());
         verify(connection3).close();
-        verifyZeroInteractions(connection1);
-        verifyZeroInteractions(connection2);
+        verifyNoInteractions(connection1);
+        verifyNoInteractions(connection2);
     }
 
     @Test
@@ -720,9 +721,9 @@ public class RequestLoadBalancerTestCase extends SdkTestCase {
         verify(factory1, atLeastOnce()).getConnectionAsync();
         verify(factory2, atLeastOnce()).getConnectionAsync();
         verify(factory3, atLeastOnce()).getConnectionAsync();
-        verifyZeroInteractions(connection1);
-        verifyZeroInteractions(connection2);
-        verifyZeroInteractions(connection3);
+        verifyNoInteractions(connection1);
+        verifyNoInteractions(connection2);
+        verifyNoInteractions(connection3);
     }
 
     // ################## Search Requests ####################
@@ -754,7 +755,7 @@ public class RequestLoadBalancerTestCase extends SdkTestCase {
                                                isNull(),
                                                any(SearchResultHandler.class));
         verify(expectedConnection).close();
-        verifyZeroInteractionsForRemainingFactories(expectedFactory);
+        verifyNoInteractionsForRemainingFactories(expectedFactory);
     }
 
     @Test
@@ -782,8 +783,8 @@ public class RequestLoadBalancerTestCase extends SdkTestCase {
                                         isNull(),
                                         any(SearchResultHandler.class));
         verify(connection3).close();
-        verifyZeroInteractions(connection1);
-        verifyZeroInteractions(connection2);
+        verifyNoInteractions(connection1);
+        verifyNoInteractions(connection2);
     }
 
     @Test
@@ -799,9 +800,9 @@ public class RequestLoadBalancerTestCase extends SdkTestCase {
         verify(factory1, atLeastOnce()).getConnectionAsync();
         verify(factory2, atLeastOnce()).getConnectionAsync();
         verify(factory3, atLeastOnce()).getConnectionAsync();
-        verifyZeroInteractions(connection1);
-        verifyZeroInteractions(connection2);
-        verifyZeroInteractions(connection3);
+        verifyNoInteractions(connection1);
+        verifyNoInteractions(connection2);
+        verifyNoInteractions(connection3);
     }
 
     @Mock private ConnectionFactory factory1;
@@ -942,15 +943,15 @@ public class RequestLoadBalancerTestCase extends SdkTestCase {
                 .thenReturn(Promises.<Connection, LdapException>newExceptionPromise(connectionFailure));
     }
 
-    private void verifyZeroInteractionsForRemainingFactories(final ConnectionFactory expectedFactory) {
+    private void verifyNoInteractionsForRemainingFactories(final ConnectionFactory expectedFactory) {
         if (expectedFactory != factory1) {
-            verifyZeroInteractions(factory1);
+            verifyNoInteractions(factory1);
         }
         if (expectedFactory != factory2) {
-            verifyZeroInteractions(factory2);
+            verifyNoInteractions(factory2);
         }
         if (expectedFactory != factory3) {
-            verifyZeroInteractions(factory3);
+            verifyNoInteractions(factory3);
         }
     }
 }

--- a/opendj-core/src/test/java/org/forgerock/opendj/ldap/schema/ObjectIdentifierEqualityMatchingRuleTest.java
+++ b/opendj-core/src/test/java/org/forgerock/opendj/ldap/schema/ObjectIdentifierEqualityMatchingRuleTest.java
@@ -12,7 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
- *
+ * Portions Copyright 2022 Wren Security
  */
 
 package org.forgerock.opendj.ldap.schema;
@@ -22,7 +22,7 @@ import static org.forgerock.opendj.ldap.ConditionResult.FALSE;
 import static org.forgerock.opendj.ldap.ConditionResult.TRUE;
 import static org.forgerock.opendj.ldap.schema.SchemaConstants.EMR_OID_NAME;
 import static org.forgerock.opendj.ldap.schema.SchemaConstants.EMR_OID_OID;
-import static org.mockito.Matchers.anyCollection;
+import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;

--- a/opendj-core/src/test/java/org/forgerock/opendj/ldap/spi/ConnectionStateTest.java
+++ b/opendj-core/src/test/java/org/forgerock/opendj/ldap/spi/ConnectionStateTest.java
@@ -12,13 +12,14 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2013-2016 ForgeRock AS.
+ * Portions Copyright 2022 Wren Security
  */
 package org.forgerock.opendj.ldap.spi;
 
 import static org.fest.assertions.Assertions.assertThat;
 import static org.forgerock.opendj.ldap.LdapException.newLdapException;
 import static org.forgerock.opendj.ldap.responses.Responses.newGenericExtendedResult;
-import static org.mockito.Matchers.same;
+import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;

--- a/opendj-core/src/test/java/org/forgerock/opendj/ldif/LDIFChangeRecordReaderTestCase.java
+++ b/opendj-core/src/test/java/org/forgerock/opendj/ldif/LDIFChangeRecordReaderTestCase.java
@@ -14,13 +14,14 @@
  * Copyright 2011-2016 ForgeRock AS.
  * Portions Copyright 2014 Manuel Gaupp
  * Portions copyright 2016 Matthew Stevenson
+ * Portions Copyright 2022 Wren Security
  */
 
 package org.forgerock.opendj.ldif;
 
 import static org.fest.assertions.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyListOf;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -925,7 +926,7 @@ public final class LDIFChangeRecordReaderTestCase extends AbstractLDIFTestCase {
                 eq(1L),
                 eq(Arrays.asList("dn: dc=example,dc=com", "changetype: add", "objectClass: top",
                         "objectClass: domainComponent", "dc: example", "xxx: unknown attribute")),
-                anyListOf(LocalizableMessage.class));
+                anyList());
         reader.close();
     }
 
@@ -969,7 +970,7 @@ public final class LDIFChangeRecordReaderTestCase extends AbstractLDIFTestCase {
                 eq(1L),
                 eq(Arrays.asList("dn: dc=example,dc=com", "changetype: add", "objectClass: top",
                         "objectClass: domainComponent", "dc: example", "xxx: unknown attribute")),
-                anyListOf(LocalizableMessage.class));
+                anyList());
         reader.close();
     }
 

--- a/opendj-core/src/test/java/org/forgerock/opendj/ldif/LDIFEntryReaderTestCase.java
+++ b/opendj-core/src/test/java/org/forgerock/opendj/ldif/LDIFEntryReaderTestCase.java
@@ -13,9 +13,14 @@
  *
  * Copyright 2009-2010 Sun Microsystems, Inc.
  * Portions copyright 2012-2016 ForgeRock AS.
+ * Portions Copyright 2022 Wren Security
  */
 package org.forgerock.opendj.ldif;
 
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.testng.Assert.assertNotNull;
 
 import java.io.File;
@@ -43,10 +48,9 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import static org.fest.assertions.Assertions.assertThat;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyListOf;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
 
 /** This class tests the LDIFEntryReader functionality. */
 @SuppressWarnings("javadoc")
@@ -615,7 +619,7 @@ public final class LDIFEntryReaderTestCase extends AbstractLDIFTestCase {
                 eq(1L),
                 eq(Arrays.asList("dn: dc=example,dc=com", "changetype: add", "objectClass: top",
                         "objectClass: domainComponent", "dc: example", "xxx: unknown attribute")),
-                anyListOf(LocalizableMessage.class));
+                anyList());
         reader.close();
     }
 
@@ -649,7 +653,7 @@ public final class LDIFEntryReaderTestCase extends AbstractLDIFTestCase {
                 eq(1L),
                 eq(Arrays.asList("dn: dc=example,dc=com", "changetype: add", "objectClass: top",
                         "objectClass: domainComponent", "dc: example", "xxx: unknown attribute")),
-                anyListOf(LocalizableMessage.class));
+                anyList());
         reader.close();
     }
 

--- a/opendj-doc-maven-plugin/pom.xml
+++ b/opendj-doc-maven-plugin/pom.xml
@@ -41,7 +41,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.forgerock.commons</groupId>
+            <groupId>org.wrensecurity.commons</groupId>
             <artifactId>i18n-core</artifactId>
         </dependency>
 
@@ -75,7 +75,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.forgerock.commons</groupId>
+                <groupId>org.wrensecurity.commons</groupId>
                 <artifactId>i18n-maven-plugin</artifactId>
                 <executions>
                     <execution>

--- a/opendj-dsml-servlet/legal-notices/THIRDPARTYREADME.txt
+++ b/opendj-dsml-servlet/legal-notices/THIRDPARTYREADME.txt
@@ -9,12 +9,14 @@ Copyright: Copyright 2011-2016 ForgeRock AS.
            Copyright (c) 2010-2011 ApexIdentity Inc. All rights reserved.
            Portions Copyright 2011-2016 ForgeRock AS.
 
-Version: i18n-core.jar (1.4.2)
+Version: i18n-core.jar (22.3.0)
 Copyright: Copyright 2011 ForgeRock AS
            Copyright 2007-2009 Sun Microsystems, Inc.
+           Portions Copyright 2022 Wren Security
 
-Version: i18n-slf4j.jar (1.4.2)
+Version: i18n-slf4j.jar (22.3.0)
 Copyright: Copyright 2011-2014 ForgeRock AS
+           Portions Copyright 2022 Wren Security
 
 Version: opendj-cli.jar (4.0.0)
 Copyright: Copyright 2014-2016 ForgeRock AS.

--- a/opendj-dsml-servlet/legal-notices/THIRDPARTYREADME.txt
+++ b/opendj-dsml-servlet/legal-notices/THIRDPARTYREADME.txt
@@ -4,9 +4,10 @@ DO NOT TRANSLATE OR LOCALIZE
 COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.0
 ***************************************************************************
 
-Version: forgerock-util.jar (20.0.0)
+Version: forgerock-util.jar (22.3.0)
 Copyright: Copyright 2011-2016 ForgeRock AS.
            Copyright (c) 2010-2011 ApexIdentity Inc. All rights reserved.
+           Portions Copyright 2022 Wren Security
            Portions Copyright 2011-2016 ForgeRock AS.
 
 Version: i18n-core.jar (22.3.0)

--- a/opendj-dsml-servlet/pom.xml
+++ b/opendj-dsml-servlet/pom.xml
@@ -47,7 +47,7 @@
 
         <!-- ForgeRock libraries -->
         <dependency>
-            <groupId>org.forgerock.commons</groupId>
+            <groupId>org.wrensecurity.commons</groupId>
             <artifactId>forgerock-util</artifactId>
         </dependency>
 

--- a/opendj-dsml-servlet/pom.xml
+++ b/opendj-dsml-servlet/pom.xml
@@ -52,12 +52,12 @@
         </dependency>
 
         <dependency>
-            <groupId>org.forgerock.commons</groupId>
+            <groupId>org.wrensecurity.commons</groupId>
             <artifactId>i18n-core</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>org.forgerock.commons</groupId>
+            <groupId>org.wrensecurity.commons</groupId>
             <artifactId>i18n-slf4j</artifactId>
         </dependency>
 

--- a/opendj-embedded-server-examples/pom.xml
+++ b/opendj-embedded-server-examples/pom.xml
@@ -13,6 +13,7 @@
   information: "Portions Copyright [year] [name of copyright owner]".
 
   Copyright 2016 ForgeRock AS.
+  Portions Copyright 2017-2021 Wren Security.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>

--- a/opendj-grizzly/pom.xml
+++ b/opendj-grizzly/pom.xml
@@ -48,7 +48,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.forgerock.commons</groupId>
+            <groupId>org.wrensecurity.commons</groupId>
             <artifactId>i18n-core</artifactId>
         </dependency>
 
@@ -74,7 +74,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.forgerock.commons</groupId>
+                <groupId>org.wrensecurity.commons</groupId>
                 <artifactId>i18n-maven-plugin</artifactId>
                 <executions>
                     <execution>

--- a/opendj-grizzly/src/test/java/org/forgerock/opendj/grizzly/GrizzlyLDAPConnectionFactoryTestCase.java
+++ b/opendj-grizzly/src/test/java/org/forgerock/opendj/grizzly/GrizzlyLDAPConnectionFactoryTestCase.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2013-2016 ForgeRock AS.
+ * Portions Copyright 2022 Wren Security
  */
 package org.forgerock.opendj.grizzly;
 
@@ -32,7 +33,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -282,7 +283,7 @@ public class GrizzlyLDAPConnectionFactoryTestCase extends SdkTestCase {
 
                 // The connection should still be valid.
                 assertThat(connection.isValid()).isTrue();
-                verifyZeroInteractions(listener);
+                verifyNoInteractions(listener);
                 /*
                  * FIXME: The search should have been abandoned (see comment in
                  * LDAPConnection for explanation).

--- a/opendj-grizzly/src/test/java/org/forgerock/opendj/grizzly/GrizzlyLDAPConnectionTestCase.java
+++ b/opendj-grizzly/src/test/java/org/forgerock/opendj/grizzly/GrizzlyLDAPConnectionTestCase.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2013-2016 ForgeRock AS.
+ * Portions Copyright 2022 Wren Security
  */
 
 package org.forgerock.opendj.grizzly;
@@ -20,7 +21,9 @@ import static org.fest.assertions.Assertions.assertThat;
 import static org.forgerock.opendj.ldap.LDAPListener.LDAP_DECODE_OPTIONS;
 import static org.forgerock.opendj.ldap.LDAPConnectionFactory.REQUEST_TIMEOUT;
 import static org.forgerock.util.time.Duration.duration;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 import java.net.InetSocketAddress;
 import java.util.Collections;
@@ -102,7 +105,7 @@ public class GrizzlyLDAPConnectionTestCase extends SdkTestCase {
             // Pass in a time which is guaranteed to trigger expiration.
             connection.handleTimeout(System.currentTimeMillis() + 1000000);
             if (isPersistentSearch) {
-                verifyZeroInteractions(searchHandler);
+                verifyNoInteractions(searchHandler);
             } else {
                 ArgumentCaptor<LdapException> arg = ArgumentCaptor.forClass(LdapException.class);
                 verify(exceptionHandler).handleException(arg.capture());

--- a/opendj-ldap-toolkit/legal-notices/THIRDPARTYREADME.txt
+++ b/opendj-ldap-toolkit/legal-notices/THIRDPARTYREADME.txt
@@ -12,12 +12,14 @@ Copyright: Copyright 2011-2016 ForgeRock AS.
 Version: grizzly-framework.jar (2.3.24)
 Copyright: Copyright (c) 2007-2015 Oracle and/or its affiliates. All rights reserved.
 
-Version: i18n-core.jar (1.4.2)
+Version: i18n-core.jar (22.3.0)
 Copyright: Copyright 2011 ForgeRock AS
            Copyright 2007-2009 Sun Microsystems, Inc.
+           Portions Copyright 2022 Wren Security
 
-Version: i18n-slf4j.jar (1.4.2)
+Version: i18n-slf4j.jar (22.3.0)
 Copyright: Copyright 2011-2014 ForgeRock AS
+           Portions Copyright 2022 Wren Security
 
 Version: opendj-cli.jar (4.0.0)
 Copyright: Copyright 2014-2016 ForgeRock AS.

--- a/opendj-ldap-toolkit/legal-notices/THIRDPARTYREADME.txt
+++ b/opendj-ldap-toolkit/legal-notices/THIRDPARTYREADME.txt
@@ -4,9 +4,10 @@ DO NOT TRANSLATE OR LOCALIZE
 COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.0
 ***************************************************************************
 
-Version: forgerock-util.jar (20.0.0)
+Version: forgerock-util.jar (22.3.0)
 Copyright: Copyright 2011-2016 ForgeRock AS.
            Copyright (c) 2010-2011 ApexIdentity Inc. All rights reserved.
+           Portions Copyright 2022 Wren Security
            Portions Copyright 2011-2016 ForgeRock AS.
 
 Version: grizzly-framework.jar (2.3.24)

--- a/opendj-ldap-toolkit/pom.xml
+++ b/opendj-ldap-toolkit/pom.xml
@@ -63,7 +63,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.forgerock.commons</groupId>
+            <groupId>org.wrensecurity.commons</groupId>
             <artifactId>i18n-core</artifactId>
         </dependency>
 
@@ -90,7 +90,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.forgerock.commons</groupId>
+                <groupId>org.wrensecurity.commons</groupId>
                 <artifactId>i18n-maven-plugin</artifactId>
                 <executions>
                     <execution>

--- a/opendj-maven-plugin/pom.xml
+++ b/opendj-maven-plugin/pom.xml
@@ -36,7 +36,7 @@
 
   <dependencies>
     <dependency>
-        <groupId>org.forgerock.commons</groupId>
+        <groupId>org.wrensecurity.commons</groupId>
         <artifactId>forgerock-util</artifactId>
     </dependency>
     <dependency>

--- a/opendj-openidm-account-change-notification-handler/legal-notices/THIRDPARTYREADME.txt
+++ b/opendj-openidm-account-change-notification-handler/legal-notices/THIRDPARTYREADME.txt
@@ -13,8 +13,9 @@ Copyright: Copyright 2015 ForgeRock AS.
            Portions Copyright 2010-2011 ApexIdentity Inc.
            Portions Copyright 2011-2016 ForgeRock AS.
 
-Version: json-crypto-core.jar (20.0.0)
+Version: json-crypto-core.jar (22.3.0)
 Copyright: Copyright 2011-2016 ForgeRock AS.
+           Portions Copyright 2022 Wren Security
 
 
 ==================

--- a/opendj-openidm-account-change-notification-handler/pom.xml
+++ b/opendj-openidm-account-change-notification-handler/pom.xml
@@ -48,7 +48,7 @@
     </dependency>
 
     <dependency>
-      <groupId>org.forgerock.commons</groupId>
+      <groupId>org.wrensecurity.commons</groupId>
       <artifactId>i18n-slf4j</artifactId>
       <scope>provided</scope>
     </dependency>
@@ -86,7 +86,7 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.forgerock.commons</groupId>
+        <groupId>org.wrensecurity.commons</groupId>
         <artifactId>i18n-maven-plugin</artifactId>
 
         <executions>

--- a/opendj-openidm-account-change-notification-handler/pom.xml
+++ b/opendj-openidm-account-change-notification-handler/pom.xml
@@ -67,7 +67,7 @@
     </dependency>
 
     <dependency>
-      <groupId>org.forgerock.commons</groupId>
+      <groupId>org.wrensecurity.commons</groupId>
       <artifactId>json-crypto-core</artifactId>
     </dependency>
 

--- a/opendj-openidm-account-change-notification-handler/pom.xml
+++ b/opendj-openidm-account-change-notification-handler/pom.xml
@@ -72,13 +72,13 @@
     </dependency>
 
     <dependency>
-      <groupId>org.forgerock.http</groupId>
+      <groupId>org.wrensecurity.http</groupId>
       <artifactId>chf-http-core</artifactId>
       <scope>provided</scope>
     </dependency>
 
     <dependency>
-      <groupId>org.forgerock.http</groupId>
+      <groupId>org.wrensecurity.http</groupId>
       <artifactId>chf-client-apache-async</artifactId>
     </dependency>
   </dependencies>

--- a/opendj-packages/opendj-zip/opendj-zip-oem/legal-notices/THIRDPARTYREADME.txt
+++ b/opendj-packages/opendj-zip/opendj-zip-oem/legal-notices/THIRDPARTYREADME.txt
@@ -73,11 +73,13 @@ Copyright: Copyright 2011-2014 ForgeRock AS
 Version: javax.mail.jar (1.5.1)
 Copyright: Copyright (c) 2005-2010 Oracle and/or its affiliates. All rights reserved.
 
-Version: json-resource.jar (20.0.0)
+Version: json-resource.jar (22.3.0)
 Copyright: Copyright 2011-2016 ForgeRock AS.
+           Portions Copyright 2022 Wren Security
 
-Version: json-resource-http.jar (20.0.0)
+Version: json-resource-http.jar (22.3.0)
 Copyright: Copyright 2012-2016 ForgeRock AS.
+           Portions Copyright 2022 Wren Security
 
 Version: opendj-cli.jar (4.0.0)
 Copyright: Copyright 2014-2016 ForgeRock AS.

--- a/opendj-packages/opendj-zip/opendj-zip-oem/legal-notices/THIRDPARTYREADME.txt
+++ b/opendj-packages/opendj-zip/opendj-zip-oem/legal-notices/THIRDPARTYREADME.txt
@@ -26,28 +26,34 @@ Version: chf-http-grizzly.jar (22.3.0)
 Copyright: Copyright 2016 ForgeRock AS.
            Portions Copyright 2022 Wren Security
 
-Version: forgerock-audit-core.jar (20.0.0)
+Version: forgerock-audit-core.jar (22.3.0)
 Copyright: Copyright 2011-2016 ForgeRock AS.
            Copyright 2013 Cybernetica AS
            Copyright 2006-2008 Sun Microsystems, Inc.
+           Portions Copyright 2022 Wren Security
            Portions Copyright 2013-2015 ForgeRock AS.
 
-Version: forgerock-audit-handler-csv.jar (20.0.0)
+Version: forgerock-audit-handler-csv.jar (22.3.0)
 Copyright: Copyright 2015-2016 ForgeRock AS.
+           Portions Copyright 2022 Wren Security
 
-Version: forgerock-audit-handler-elasticsearch.jar (20.0.0)
+Version: forgerock-audit-handler-elasticsearch.jar (22.3.0)
 Copyright: Copyright 2016 ForgeRock AS.
+           Portions Copyright 2022 Wren Security
 
-Version: forgerock-audit-handler-jdbc.jar (20.0.0)
+Version: forgerock-audit-handler-jdbc.jar (22.3.0)
 Copyright: Copyright 2015-2016 ForgeRock AS.
-Portions Copyright 2016 Nomura Research Institute, Ltd.
+           Portions Copyright 2022 Wren Security
+           Portions Copyright 2016 Nomura Research Institute, Ltd.
 
-Version: forgerock-audit-handler-syslog.jar (20.0.0)
+Version: forgerock-audit-handler-syslog.jar (22.3.0)
 Copyright: Copyright 2015-2016 ForgeRock AS.
            Copyright 2013 Cybernetica AS
+           Portions Copyright 2022 Wren Security
 
-Version: forgerock-audit-json.jar (20.0.0)
+Version: forgerock-audit-json.jar (22.3.0)
 Copyright: Copyright 2015-2016 ForgeRock AS.
+           Portions Copyright 2022 Wren Security
 
 Version: forgerock-util.jar (22.3.0)
 Copyright: Copyright 2011-2016 ForgeRock AS.

--- a/opendj-packages/opendj-zip/opendj-zip-oem/legal-notices/THIRDPARTYREADME.txt
+++ b/opendj-packages/opendj-zip/opendj-zip-oem/legal-notices/THIRDPARTYREADME.txt
@@ -61,12 +61,14 @@ Copyright (c) 2004 Mikael Grev, MiG InfoCom AB. (base64 @ miginfocom . com)
 Version: grizzly-http-server.jar (2.3.24)
 Copyright: Copyright (c) 1997-2016 Oracle and/or its affiliates. All rights reserved.
 
-Version: i18n-core.jar (1.4.2)
+Version: i18n-core.jar (22.3.0)
 Copyright: Copyright 2011 ForgeRock AS
            Copyright 2007-2009 Sun Microsystems, Inc.
+           Portions Copyright 2022 Wren Security
 
-Version: i18n-slf4j.jar (1.4.2)
+Version: i18n-slf4j.jar (22.3.0)
 Copyright: Copyright 2011-2014 ForgeRock AS
+           Portions Copyright 2022 Wren Security
 
 Version: javax.mail.jar (1.5.1)
 Copyright: Copyright (c) 2005-2010 Oracle and/or its affiliates. All rights reserved.

--- a/opendj-packages/opendj-zip/opendj-zip-oem/legal-notices/THIRDPARTYREADME.txt
+++ b/opendj-packages/opendj-zip/opendj-zip-oem/legal-notices/THIRDPARTYREADME.txt
@@ -46,9 +46,10 @@ Copyright: Copyright 2015-2016 ForgeRock AS.
 Version: forgerock-audit-json.jar (20.0.0)
 Copyright: Copyright 2015-2016 ForgeRock AS.
 
-Version: forgerock-util.jar (20.0.0)
+Version: forgerock-util.jar (22.3.0)
 Copyright: Copyright 2011-2016 ForgeRock AS.
            Copyright (c) 2010-2011 ApexIdentity Inc. All rights reserved.
+           Portions Copyright 2022 Wren Security
            Portions Copyright 2011-2016 ForgeRock AS.
 
 Version: grizzly-framework.jar (2.3.24)

--- a/opendj-packages/opendj-zip/opendj-zip-oem/legal-notices/THIRDPARTYREADME.txt
+++ b/opendj-packages/opendj-zip/opendj-zip-oem/legal-notices/THIRDPARTYREADME.txt
@@ -4,24 +4,27 @@ DO NOT TRANSLATE OR LOCALIZE
 COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.0
 ***************************************************************************
 
-Version: chf-client-apache-async.jar (20.0.0)
+Version: chf-client-apache-async.jar (22.3.0)
 Copyright: Copyright 2015 ForgeRock AS.
            Copyright 2009 Sun Microsystems Inc.
+           Portions Copyright 2022 Wren Security
            Portions Copyright 2010-2011 ApexIdentity Inc.
            Portions Copyright 2011-2016 ForgeRock AS.
 
 Version: chf-client-apache-common.jar (20.0.0)
 Copyright: Copyright 2015 ForgeRock AS.
 
-Version: chf-http-core.jar (20.0.0)
+Version: chf-http-core.jar (22.3.0)
 Copyright: Copyright 2012-2016 ForgeRock AS.
            Copyright 2010-2011 ApexIdentity Inc.
            Copyright 2009 Sun Microsystems Inc.
+           Portions Copyright 2022 Wren Security
            Portions Copyright 2011-2016 ForgeRock AS.
            Portions Copyright 2010-2011 ApexIdentity Inc.
 
-Version: chf-http-grizzly.jar (20.0.0)
+Version: chf-http-grizzly.jar (22.3.0)
 Copyright: Copyright 2016 ForgeRock AS.
+           Portions Copyright 2022 Wren Security
 
 Version: forgerock-audit-core.jar (20.0.0)
 Copyright: Copyright 2011-2016 ForgeRock AS.

--- a/opendj-rest2ldap-servlet/legal-notices/THIRDPARTYREADME.txt
+++ b/opendj-rest2ldap-servlet/legal-notices/THIRDPARTYREADME.txt
@@ -36,12 +36,14 @@ Copyright: Copyright 2011-2016 ForgeRock AS.
 Version: grizzly-framework.jar (2.3.24)
 Copyright: Copyright (c) 2007-2015 Oracle and/or its affiliates. All rights reserved.
 
-Version: i18n-core.jar (1.4.2)
+Version: i18n-core.jar (22.3.0)
 Copyright: Copyright 2011 ForgeRock AS
            Copyright 2007-2009 Sun Microsystems, Inc.
+           Portions Copyright 2022 Wren Security
 
-Version: i18n-slf4j.jar (1.4.2)
+Version: i18n-slf4j.jar (22.3.0)
 Copyright: Copyright 2011-2014 ForgeRock AS
+           Portions Copyright 2022 Wren Security
 
 Version: javax.mail.jar (1.5.1)
 Copyright: Copyright (c) 2005-2010 Oracle and/or its affiliates. All rights reserved.

--- a/opendj-rest2ldap-servlet/legal-notices/THIRDPARTYREADME.txt
+++ b/opendj-rest2ldap-servlet/legal-notices/THIRDPARTYREADME.txt
@@ -28,9 +28,10 @@ Copyright: Copyright 2012-2015 ForgeRock AS.
            Copyright 2010-2011 ApexIdentity Inc.
            Portions Copyright 2011-2016 ForgeRock AS.
 
-Version: forgerock-util.jar (20.0.0)
+Version: forgerock-util.jar (22.3.0)
 Copyright: Copyright 2011-2016 ForgeRock AS.
            Copyright (c) 2010-2011 ApexIdentity Inc. All rights reserved.
+           Portions Copyright 2022 Wren Security
            Portions Copyright 2011-2016 ForgeRock AS.
 
 Version: grizzly-framework.jar (2.3.24)

--- a/opendj-rest2ldap-servlet/legal-notices/THIRDPARTYREADME.txt
+++ b/opendj-rest2ldap-servlet/legal-notices/THIRDPARTYREADME.txt
@@ -48,11 +48,13 @@ Copyright: Copyright 2011-2014 ForgeRock AS
 Version: javax.mail.jar (1.5.1)
 Copyright: Copyright (c) 2005-2010 Oracle and/or its affiliates. All rights reserved.
 
-Version: json-resource.jar (20.0.0)
+Version: json-resource.jar (22.3.0)
 Copyright: Copyright 2011-2016 ForgeRock AS.
+           Portions Copyright 2022 Wren Security
 
-Version: json-resource-http.jar (20.0.0)
+Version: json-resource-http.jar (22.3.0)
 Copyright: Copyright 2012-2016 ForgeRock AS.
+           Portions Copyright 2022 Wren Security
 
 Version: opendj-core.jar (4.0.0)
 Copyright: Copyright 2011-2016 ForgeRock AS.

--- a/opendj-rest2ldap-servlet/legal-notices/THIRDPARTYREADME.txt
+++ b/opendj-rest2ldap-servlet/legal-notices/THIRDPARTYREADME.txt
@@ -7,25 +7,28 @@ COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.0
 Version: activation.jar (1.1)
 Copyright: Copyright 1997-2007 Sun Microsystems, Inc. All rights reserved.
 
-Version: chf-client-apache-async.jar (20.0.0)
+Version: chf-client-apache-async.jar (22.3.0)
 Copyright: Copyright 2015 ForgeRock AS.
            Copyright 2009 Sun Microsystems Inc.
+           Portions Copyright 2022 Wren Security
            Portions Copyright 2010-2011 ApexIdentity Inc.
            Portions Copyright 2011-2016 ForgeRock AS.
 
 Version: chf-client-apache-common.jar (20.0.0)
 Copyright: Copyright 2015 ForgeRock AS.
 
-Version: chf-http-core.jar (20.0.0)
+Version: chf-http-core.jar (22.3.0)
 Copyright: Copyright 2012-2016 ForgeRock AS.
            Copyright 2010-2011 ApexIdentity Inc.
            Copyright 2009 Sun Microsystems Inc.
+           Portions Copyright 2022 Wren Security
            Portions Copyright 2011-2016 ForgeRock AS.
            Portions Copyright 2010-2011 ApexIdentity Inc.
 
-Version: chf-http-servlet.jar (20.0.0)
+Version: chf-http-servlet.jar (22.3.0)
 Copyright: Copyright 2012-2015 ForgeRock AS.
            Copyright 2010-2011 ApexIdentity Inc.
+           Portions Copyright 2022 Wren Security
            Portions Copyright 2011-2016 ForgeRock AS.
 
 Version: forgerock-util.jar (22.3.0)

--- a/opendj-rest2ldap-servlet/pom.xml
+++ b/opendj-rest2ldap-servlet/pom.xml
@@ -42,7 +42,7 @@
     </dependency>
 
     <dependency>
-      <groupId>org.forgerock.http</groupId>
+      <groupId>org.wrensecurity.http</groupId>
       <artifactId>chf-http-servlet</artifactId>
     </dependency>
 

--- a/opendj-rest2ldap/pom.xml
+++ b/opendj-rest2ldap/pom.xml
@@ -58,7 +58,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.forgerock.commons</groupId>
+            <groupId>org.wrensecurity.commons</groupId>
             <artifactId>i18n-core</artifactId>
         </dependency>
 
@@ -83,7 +83,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.forgerock.commons</groupId>
+                <groupId>org.wrensecurity.commons</groupId>
                 <artifactId>i18n-maven-plugin</artifactId>
                 <executions>
                     <execution>

--- a/opendj-rest2ldap/pom.xml
+++ b/opendj-rest2ldap/pom.xml
@@ -63,12 +63,12 @@
         </dependency>
 
         <dependency>
-            <groupId>org.forgerock.http</groupId>
+            <groupId>org.wrensecurity.http</groupId>
             <artifactId>chf-oauth2</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>org.forgerock.http</groupId>
+            <groupId>org.wrensecurity.http</groupId>
             <artifactId>chf-client-apache-async</artifactId>
         </dependency>
 

--- a/opendj-rest2ldap/pom.xml
+++ b/opendj-rest2ldap/pom.xml
@@ -53,7 +53,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.forgerock.commons</groupId>
+            <groupId>org.wrensecurity.commons</groupId>
             <artifactId>forgerock-util</artifactId>
         </dependency>
 

--- a/opendj-rest2ldap/pom.xml
+++ b/opendj-rest2ldap/pom.xml
@@ -43,12 +43,12 @@
         </dependency>
 
         <dependency>
-            <groupId>org.forgerock.commons</groupId>
+            <groupId>org.wrensecurity.commons</groupId>
             <artifactId>json-resource</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>org.forgerock.commons</groupId>
+            <groupId>org.wrensecurity.commons</groupId>
             <artifactId>json-resource-http</artifactId>
         </dependency>
 

--- a/opendj-rest2ldap/src/test/java/org/forgerock/opendj/rest2ldap/AuthorizationTestCase.java
+++ b/opendj-rest2ldap/src/test/java/org/forgerock/opendj/rest2ldap/AuthorizationTestCase.java
@@ -12,11 +12,12 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions Copyright 2022 Wren Security
  */
 package org.forgerock.opendj.rest2ldap;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 

--- a/opendj-rest2ldap/src/test/java/org/forgerock/opendj/rest2ldap/OAuth2JsonConfigurationTestCase.java
+++ b/opendj-rest2ldap/src/test/java/org/forgerock/opendj/rest2ldap/OAuth2JsonConfigurationTestCase.java
@@ -12,12 +12,13 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions Copyright 2022 Wren Security
  */
 package org.forgerock.opendj.rest2ldap;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.forgerock.opendj.rest2ldap.TestUtils.parseJson;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;

--- a/opendj-rest2ldap/src/test/java/org/forgerock/opendj/rest2ldap/authz/CtsAccessTokenResolverTestCase.java
+++ b/opendj-rest2ldap/src/test/java/org/forgerock/opendj/rest2ldap/authz/CtsAccessTokenResolverTestCase.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions Copyright 2022 Wren Security
  */
 package org.forgerock.opendj.rest2ldap.authz;
 
@@ -20,7 +21,7 @@ import static org.forgerock.opendj.ldap.LdapException.newLdapException;
 import static org.forgerock.opendj.ldap.spi.LdapPromises.newSuccessfulLdapPromise;
 import static org.forgerock.opendj.rest2ldap.TestUtils.toValidJson;
 import static org.forgerock.opendj.rest2ldap.authz.Authorization.newCtsAccessTokenResolver;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/opendj-rest2ldap/src/test/java/org/forgerock/opendj/rest2ldap/authz/HttpBasicAuthenticationFilterTest.java
+++ b/opendj-rest2ldap/src/test/java/org/forgerock/opendj/rest2ldap/authz/HttpBasicAuthenticationFilterTest.java
@@ -12,13 +12,14 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions Copyright 2022 Wren Security
  */
 package org.forgerock.opendj.rest2ldap.authz;
 
 import static org.fest.assertions.Assertions.assertThat;
 import static org.forgerock.opendj.rest2ldap.authz.Authorization.newConditionalHttpBasicAuthenticationFilter;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;

--- a/opendj-rest2ldap/src/test/java/org/forgerock/opendj/rest2ldap/authz/ProxiedAuthV2FilterTest.java
+++ b/opendj-rest2ldap/src/test/java/org/forgerock/opendj/rest2ldap/authz/ProxiedAuthV2FilterTest.java
@@ -12,11 +12,12 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions Copyright 2022 Wren Security
  */
 package org.forgerock.opendj.rest2ldap.authz;
 
 import static org.fest.assertions.Assertions.assertThat;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/opendj-rest2ldap/src/test/java/org/forgerock/opendj/rest2ldap/authz/Rfc7662AccessResolverTestCase.java
+++ b/opendj-rest2ldap/src/test/java/org/forgerock/opendj/rest2ldap/authz/Rfc7662AccessResolverTestCase.java
@@ -12,13 +12,14 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions Copyright 2022 Wren Security
  */
 package org.forgerock.opendj.rest2ldap.authz;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.forgerock.opendj.rest2ldap.authz.Authorization.newRfc7662AccessTokenResolver;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 

--- a/opendj-server-example-plugin/pom.xml
+++ b/opendj-server-example-plugin/pom.xml
@@ -45,7 +45,7 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.forgerock.commons</groupId>
+        <groupId>org.wrensecurity.commons</groupId>
         <artifactId>i18n-maven-plugin</artifactId>
         <executions>
           <execution>

--- a/opendj-server-legacy/legal-notices/THIRDPARTYREADME.txt
+++ b/opendj-server-legacy/legal-notices/THIRDPARTYREADME.txt
@@ -73,11 +73,13 @@ Copyright: Copyright 2011-2014 ForgeRock AS
 Version: javax.mail.jar (1.5.1)
 Copyright: Copyright (c) 2005-2010 Oracle and/or its affiliates. All rights reserved.
 
-Version: json-resource.jar (20.0.0)
+Version: json-resource.jar (22.3.0)
 Copyright: Copyright 2011-2016 ForgeRock AS.
+           Portions Copyright 2022 Wren Security
 
-Version: json-resource-http.jar (20.0.0)
+Version: json-resource-http.jar (22.3.0)
 Copyright: Copyright 2012-2016 ForgeRock AS.
+           Portions Copyright 2022 Wren Security
 
 Version: opendj-cli.jar (4.0.0)
 Copyright: Copyright 2014-2016 ForgeRock AS.

--- a/opendj-server-legacy/legal-notices/THIRDPARTYREADME.txt
+++ b/opendj-server-legacy/legal-notices/THIRDPARTYREADME.txt
@@ -26,28 +26,34 @@ Version: chf-http-grizzly.jar (22.3.0)
 Copyright: Copyright 2016 ForgeRock AS.
            Portions Copyright 2022 Wren Security
 
-Version: forgerock-audit-core.jar (20.0.0)
+Version: forgerock-audit-core.jar (22.3.0)
 Copyright: Copyright 2011-2016 ForgeRock AS.
            Copyright 2013 Cybernetica AS
            Copyright 2006-2008 Sun Microsystems, Inc.
+           Portions Copyright 2022 Wren Security
            Portions Copyright 2013-2015 ForgeRock AS.
 
-Version: forgerock-audit-handler-csv.jar (20.0.0)
+Version: forgerock-audit-handler-csv.jar (22.3.0)
 Copyright: Copyright 2015-2016 ForgeRock AS.
+           Portions Copyright 2022 Wren Security
 
-Version: forgerock-audit-handler-elasticsearch.jar (20.0.0)
+Version: forgerock-audit-handler-elasticsearch.jar (22.3.0)
 Copyright: Copyright 2016 ForgeRock AS.
+           Portions Copyright 2022 Wren Security
 
-Version: forgerock-audit-handler-jdbc.jar (20.0.0)
+Version: forgerock-audit-handler-jdbc.jar (22.3.0)
 Copyright: Copyright 2015-2016 ForgeRock AS.
-Portions Copyright 2016 Nomura Research Institute, Ltd.
+           Portions Copyright 2022 Wren Security
+           Portions Copyright 2016 Nomura Research Institute, Ltd.
 
-Version: forgerock-audit-handler-syslog.jar (20.0.0)
+Version: forgerock-audit-handler-syslog.jar (22.3.0)
 Copyright: Copyright 2015-2016 ForgeRock AS.
            Copyright 2013 Cybernetica AS
+           Portions Copyright 2022 Wren Security
 
-Version: forgerock-audit-json.jar (20.0.0)
+Version: forgerock-audit-json.jar (22.3.0)
 Copyright: Copyright 2015-2016 ForgeRock AS.
+           Portions Copyright 2022 Wren Security
 
 Version: forgerock-util.jar (22.3.0)
 Copyright: Copyright 2011-2016 ForgeRock AS.

--- a/opendj-server-legacy/legal-notices/THIRDPARTYREADME.txt
+++ b/opendj-server-legacy/legal-notices/THIRDPARTYREADME.txt
@@ -61,12 +61,14 @@ Copyright (c) 2004 Mikael Grev, MiG InfoCom AB. (base64 @ miginfocom . com)
 Version: grizzly-http-server.jar (2.3.24)
 Copyright: Copyright (c) 1997-2016 Oracle and/or its affiliates. All rights reserved.
 
-Version: i18n-core.jar (1.4.2)
+Version: i18n-core.jar (22.3.0)
 Copyright: Copyright 2011 ForgeRock AS
            Copyright 2007-2009 Sun Microsystems, Inc.
+           Portions Copyright 2022 Wren Security
 
-Version: i18n-slf4j.jar (1.4.2)
+Version: i18n-slf4j.jar (22.3.0)
 Copyright: Copyright 2011-2014 ForgeRock AS
+           Portions Copyright 2022 Wren Security
 
 Version: javax.mail.jar (1.5.1)
 Copyright: Copyright (c) 2005-2010 Oracle and/or its affiliates. All rights reserved.

--- a/opendj-server-legacy/legal-notices/THIRDPARTYREADME.txt
+++ b/opendj-server-legacy/legal-notices/THIRDPARTYREADME.txt
@@ -46,9 +46,10 @@ Copyright: Copyright 2015-2016 ForgeRock AS.
 Version: forgerock-audit-json.jar (20.0.0)
 Copyright: Copyright 2015-2016 ForgeRock AS.
 
-Version: forgerock-util.jar (20.0.0)
+Version: forgerock-util.jar (22.3.0)
 Copyright: Copyright 2011-2016 ForgeRock AS.
            Copyright (c) 2010-2011 ApexIdentity Inc. All rights reserved.
+           Portions Copyright 2022 Wren Security
            Portions Copyright 2011-2016 ForgeRock AS.
 
 Version: grizzly-framework.jar (2.3.24)

--- a/opendj-server-legacy/legal-notices/THIRDPARTYREADME.txt
+++ b/opendj-server-legacy/legal-notices/THIRDPARTYREADME.txt
@@ -4,24 +4,27 @@ DO NOT TRANSLATE OR LOCALIZE
 COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.0
 ***************************************************************************
 
-Version: chf-client-apache-async.jar (20.0.0)
+Version: chf-client-apache-async.jar (22.3.0)
 Copyright: Copyright 2015 ForgeRock AS.
            Copyright 2009 Sun Microsystems Inc.
+           Portions Copyright 2022 Wren Security
            Portions Copyright 2010-2011 ApexIdentity Inc.
            Portions Copyright 2011-2016 ForgeRock AS.
 
 Version: chf-client-apache-common.jar (20.0.0)
 Copyright: Copyright 2015 ForgeRock AS.
 
-Version: chf-http-core.jar (20.0.0)
+Version: chf-http-core.jar (22.3.0)
 Copyright: Copyright 2012-2016 ForgeRock AS.
            Copyright 2010-2011 ApexIdentity Inc.
            Copyright 2009 Sun Microsystems Inc.
+           Portions Copyright 2022 Wren Security
            Portions Copyright 2011-2016 ForgeRock AS.
            Portions Copyright 2010-2011 ApexIdentity Inc.
 
-Version: chf-http-grizzly.jar (20.0.0)
+Version: chf-http-grizzly.jar (22.3.0)
 Copyright: Copyright 2016 ForgeRock AS.
+           Portions Copyright 2022 Wren Security
 
 Version: forgerock-audit-core.jar (20.0.0)
 Copyright: Copyright 2011-2016 ForgeRock AS.

--- a/opendj-server-legacy/pom.xml
+++ b/opendj-server-legacy/pom.xml
@@ -105,7 +105,7 @@
     </dependency>
 
     <dependency>
-      <groupId>org.forgerock.commons</groupId>
+      <groupId>org.wrensecurity.commons</groupId>
       <artifactId>forgerock-util</artifactId>
     </dependency>
 

--- a/opendj-server-legacy/pom.xml
+++ b/opendj-server-legacy/pom.xml
@@ -120,12 +120,12 @@
     </dependency>
 
     <dependency>
-      <groupId>org.forgerock.http</groupId>
+      <groupId>org.wrensecurity.http</groupId>
       <artifactId>chf-http-core</artifactId>
     </dependency>
 
     <dependency>
-      <groupId>org.forgerock.http</groupId>
+      <groupId>org.wrensecurity.http</groupId>
       <artifactId>chf-http-grizzly</artifactId>
     </dependency>
 

--- a/opendj-server-legacy/pom.xml
+++ b/opendj-server-legacy/pom.xml
@@ -131,47 +131,47 @@
 
     <!-- ForgeRock Common Audit libraries -->
     <dependency>
-      <groupId>org.forgerock.commons</groupId>
+      <groupId>org.wrensecurity.commons</groupId>
       <artifactId>forgerock-audit-core</artifactId>
     </dependency>
 
     <dependency>
-      <groupId>org.forgerock.commons</groupId>
+      <groupId>org.wrensecurity.commons</groupId>
       <artifactId>forgerock-audit-handler-csv</artifactId>
     </dependency>
 
     <dependency>
-      <groupId>org.forgerock.commons</groupId>
+      <groupId>org.wrensecurity.commons</groupId>
       <artifactId>forgerock-audit-handler-json</artifactId>
     </dependency>
 
     <dependency>
-      <groupId>org.forgerock.commons</groupId>
+      <groupId>org.wrensecurity.commons</groupId>
       <artifactId>forgerock-audit-handler-elasticsearch</artifactId>
     </dependency>
 
     <dependency>
-      <groupId>org.forgerock.commons</groupId>
+      <groupId>org.wrensecurity.commons</groupId>
       <artifactId>forgerock-audit-handler-splunk</artifactId>
     </dependency>
 
     <dependency>
-      <groupId>org.forgerock.commons</groupId>
+      <groupId>org.wrensecurity.commons</groupId>
       <artifactId>forgerock-audit-handler-jms</artifactId>
     </dependency>
 
     <dependency>
-      <groupId>org.forgerock.commons</groupId>
+      <groupId>org.wrensecurity.commons</groupId>
       <artifactId>forgerock-audit-json</artifactId>
     </dependency>
 
     <dependency>
-      <groupId>org.forgerock.commons</groupId>
+      <groupId>org.wrensecurity.commons</groupId>
       <artifactId>forgerock-audit-handler-syslog</artifactId>
     </dependency>
 
     <dependency>
-      <groupId>org.forgerock.commons</groupId>
+      <groupId>org.wrensecurity.commons</groupId>
       <artifactId>forgerock-audit-handler-jdbc</artifactId>
     </dependency>
 

--- a/opendj-server-legacy/pom.xml
+++ b/opendj-server-legacy/pom.xml
@@ -71,7 +71,7 @@
     </dependency>
 
     <dependency>
-      <groupId>org.forgerock.commons</groupId>
+      <groupId>org.wrensecurity.commons</groupId>
       <artifactId>i18n-slf4j</artifactId>
     </dependency>
 
@@ -321,7 +321,7 @@
       <!-- Generate i18n messages -->
       <plugin>
         <?m2e execute onConfiguration?>
-        <groupId>org.forgerock.commons</groupId>
+        <groupId>org.wrensecurity.commons</groupId>
         <artifactId>i18n-maven-plugin</artifactId>
         <executions>
           <execution>

--- a/opendj-server-legacy/pom.xml
+++ b/opendj-server-legacy/pom.xml
@@ -110,12 +110,12 @@
     </dependency>
 
     <dependency>
-      <groupId>org.forgerock.commons</groupId>
+      <groupId>org.wrensecurity.commons</groupId>
       <artifactId>json-resource</artifactId>
     </dependency>
 
     <dependency>
-      <groupId>org.forgerock.commons</groupId>
+      <groupId>org.wrensecurity.commons</groupId>
       <artifactId>json-resource-http</artifactId>
     </dependency>
 

--- a/opendj-server-legacy/src/test/java/org/opends/server/replication/plugin/AttrHistoricalMultipleTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/replication/plugin/AttrHistoricalMultipleTest.java
@@ -13,13 +13,20 @@
  *
  * Copyright 2006-2010 Sun Microsystems, Inc.
  * Portions Copyright 2013-2016 ForgeRock AS.
+ * Portions Copyright 2022 Wren Security
  */
 package org.opends.server.replication.plugin;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.forgerock.opendj.ldap.ModificationType.*;
-import static org.mockito.Mockito.*;
-import static org.testng.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.forgerock.opendj.ldap.ModificationType.ADD;
+import static org.forgerock.opendj.ldap.ModificationType.DELETE;
+import static org.forgerock.opendj.ldap.ModificationType.REPLACE;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.only;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.testng.Assert.assertEquals;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -398,7 +405,7 @@ public class AttrHistoricalMultipleTest extends ReplicationTestCase
   {
     Iterator<Modification> itMod = mock(Iterator.class);
     replayOperation(itMod, csn, entry, mod, shouldConflict);
-    verifyZeroInteractions(itMod);
+    verifyNoInteractions(itMod);
   }
 
   private void replayOperation(Iterator<Modification> modsIterator, CSN csn, Entry entry, Modification mod,

--- a/opendj-server-legacy/src/test/java/org/opends/server/replication/plugin/AttrHistoricalSingleTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/replication/plugin/AttrHistoricalSingleTest.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
+ * Portions Copyright 2022 Wren Security
  */
 package org.opends.server.replication.plugin;
 
@@ -292,7 +293,7 @@ public class AttrHistoricalSingleTest extends ReplicationTestCase
   {
     Iterator<Modification> itMod = mock(Iterator.class);
     replayOperation(itMod, csn, entry, mod, shouldConflict);
-    verifyZeroInteractions(itMod);
+    verifyNoInteractions(itMod);
   }
 
   private void replayOperationSuppressMod(CSN csn, Entry entry, Modification mod, boolean shouldConflict)

--- a/opendj-server/pom.xml
+++ b/opendj-server/pom.xml
@@ -51,7 +51,7 @@
       <artifactId>opendj-config</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.forgerock.commons</groupId>
+      <groupId>org.wrensecurity.commons</groupId>
       <artifactId>forgerock-util</artifactId>
     </dependency>
     <dependency>

--- a/opendj-server/pom.xml
+++ b/opendj-server/pom.xml
@@ -55,7 +55,7 @@
       <artifactId>forgerock-util</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.forgerock.commons</groupId>
+      <groupId>org.wrensecurity.commons</groupId>
       <artifactId>i18n-core</artifactId>
     </dependency>
     <dependency>
@@ -102,7 +102,7 @@
       </plugin>
 
       <plugin>
-        <groupId>org.forgerock.commons</groupId>
+        <groupId>org.wrensecurity.commons</groupId>
         <artifactId>i18n-maven-plugin</artifactId>
         <executions>
           <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -261,9 +261,9 @@
                 </plugin>
 
                 <plugin>
-                    <groupId>org.forgerock.commons</groupId>
+                    <groupId>org.wrensecurity.commons</groupId>
                     <artifactId>i18n-maven-plugin</artifactId>
-                    <version>${i18n-framework.version}</version>
+                    <version>${wrensec-commons.version}</version>
                 </plugin>
 
                 <plugin>


### PR DESCRIPTION
Replacing of ForgeRock dependencies with Wren Security.

List of upgrades:

* `org.wrensecurity:wrensec-parent:3.3.0` → `org.wrensecurity:wrensec-parent:3.4.0`
* `org.forgerock.commons:forgerock-audit-*` → `org.wrensecurity.commons:forgerock-audit-*:22.3.0`
* `org.forgerock.commons:forgerock-util` → `org.wrensecurity.commons:forgerock-util:22.3.0`
* `org.forgerock.commons:i18n-*` → `org.wrensecurity.commons:i18n-*:22.3.0`
* `org.forgerock.commons:json-crypto-core` → `org.wrensecurity.commons:json-crypto-core:22.3.0`
* `org.forgerock.commons:json-resource*` → `org.wrensecurity.commons:json-resource*:22.3.0`
* `org.forgerock.http:chf-*` → `org.wrensecurity.http:chf-:22.3.0`
<!---->
* `org.wrensecurity:wrensec-pgp-whitelist:1.5.5` → `1.6.0`

Some ForgeRock dependencies doesn't have Wren replacement:

* `org.forgerock.commons:forgerock-doc-maven-plugin`
* `org.forgerock.commons:forgerock-persistit-core:4.3.2-SNAPSHOT`
