### PR TITLE
Cleanup project structure and change groupId

### DIFF
--- a/.wren-deploy.rc
+++ b/.wren-deploy.rc
@@ -1,1 +1,0 @@
-export MAVEN_PACKAGE="opendj"

--- a/opendj-bom/pom.xml
+++ b/opendj-bom/pom.xml
@@ -13,7 +13,7 @@
   information: "Portions Copyright [year] [name of copyright owner]".
 
   Copyright 2011-2016 ForgeRock AS.
-  Portions Copyright 2017-2021 Wren Security.
+  Portions Copyright 2017-2022 Wren Security.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -25,10 +25,9 @@
         <relativePath />
     </parent>
 
-    <groupId>org.forgerock.opendj</groupId>
+    <groupId>org.wrensecurity.wrends</groupId>
     <artifactId>opendj-bom</artifactId>
     <version>4.0.0-M4-SNAPSHOT</version>
-
     <packaging>pom</packaging>
 
     <name>Wren:DS BOM</name>
@@ -37,7 +36,6 @@
     </description>
 
     <repositories>
-        <!-- Needed to retrieve parent POM -->
         <repository>
             <id>wrensecurity-releases</id>
             <name>Wren Security Release Repository</name>
@@ -52,7 +50,6 @@
             </releases>
         </repository>
 
-        <!-- Needed to retrieve parent POM -->
         <repository>
             <id>wrensecurity-snapshots</id>
             <name>Wren Security Snapshot Repository</name>
@@ -70,7 +67,6 @@
 
     <properties>
         <wrensec-commons.version>22.3.0</wrensec-commons.version>
-        <pgpWhitelistArtifact>org.wrensecurity:wrensec-pgp-whitelist:1.6.0</pgpWhitelistArtifact>
     </properties>
 
     <dependencyManagement>
@@ -93,25 +89,25 @@
 
             <!-- Wren:DS SDK -->
             <dependency>
-                <groupId>org.forgerock.opendj</groupId>
+                <groupId>org.wrensecurity.wrends</groupId>
                 <artifactId>opendj-core</artifactId>
                 <version>${project.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>org.forgerock.opendj</groupId>
+                <groupId>org.wrensecurity.wrends</groupId>
                 <artifactId>opendj-cli</artifactId>
                 <version>${project.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>org.forgerock.opendj</groupId>
+                <groupId>org.wrensecurity.wrends</groupId>
                 <artifactId>opendj-grizzly</artifactId>
                 <version>${project.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>org.forgerock.opendj</groupId>
+                <groupId>org.wrensecurity.wrends</groupId>
                 <artifactId>opendj-rest2ldap</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/opendj-cli/pom.xml
+++ b/opendj-cli/pom.xml
@@ -13,14 +13,14 @@
   information: "Portions Copyright [year] [name of copyright owner]".
 
   Copyright 2014-2016 ForgeRock AS.
-  Portions Copyright 2018-2021 Wren Security.
+  Portions Copyright 2018-2022 Wren Security.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.forgerock.opendj</groupId>
-        <artifactId>opendj-parent</artifactId>
+        <groupId>org.wrensecurity.wrends</groupId>
+        <artifactId>opendj-project</artifactId>
         <version>4.0.0-M4-SNAPSHOT</version>
     </parent>
 
@@ -32,12 +32,12 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.forgerock.opendj</groupId>
+            <groupId>org.wrensecurity.wrends</groupId>
             <artifactId>opendj-core</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>org.forgerock.opendj</groupId>
+            <groupId>org.wrensecurity.wrends</groupId>
             <artifactId>opendj-core</artifactId>
             <type>test-jar</type>
             <scope>test</scope>
@@ -96,8 +96,8 @@
             </plugin>
 
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>cobertura-maven-plugin</artifactId>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
             </plugin>
 
             <!-- Creates opendj-cli bundle -->
@@ -130,16 +130,6 @@
                         </reports>
                     </reportSet>
                 </reportSets>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <configuration>
-                    <links>
-                        <link>http://commons.forgerock.org/i18n-framework/i18n-core/apidocs</link>
-                    </links>
-                </configuration>
             </plugin>
         </plugins>
     </reporting>

--- a/opendj-config/pom.xml
+++ b/opendj-config/pom.xml
@@ -13,13 +13,13 @@
   information: "Portions Copyright [year] [name of copyright owner]".
 
   Copyright 2013-2016 ForgeRock AS.
-  Portions Copyright 2017-2021 Wren Security.
+  Portions Copyright 2017-2022 Wren Security.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.forgerock.opendj</groupId>
-    <artifactId>opendj-parent</artifactId>
+    <groupId>org.wrensecurity.wrends</groupId>
+    <artifactId>opendj-project</artifactId>
     <version>4.0.0-M4-SNAPSHOT</version>
   </parent>
   <artifactId>opendj-config</artifactId>
@@ -46,17 +46,17 @@
       <artifactId>wrensec-build-tools</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.forgerock.opendj</groupId>
+      <groupId>org.wrensecurity.wrends</groupId>
       <artifactId>opendj-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.forgerock.opendj</groupId>
+      <groupId>org.wrensecurity.wrends</groupId>
       <artifactId>opendj-core</artifactId>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.forgerock.opendj</groupId>
+      <groupId>org.wrensecurity.wrends</groupId>
       <artifactId>opendj-cli</artifactId>
     </dependency>
   </dependencies>
@@ -140,7 +140,7 @@
       </plugin>
       <!-- Validate core components XML definition files and generate the components. -->
       <plugin>
-        <groupId>org.forgerock.opendj</groupId>
+        <groupId>org.wrensecurity.wrends</groupId>
         <artifactId>opendj-maven-plugin</artifactId>
         <executions>
           <execution>
@@ -169,17 +169,15 @@
         <artifactId>maven-surefire-plugin</artifactId>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>cobertura-maven-plugin</artifactId>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
         <configuration>
-          <instrumentation>
             <excludes>
               <exclude>**/*Messages.class</exclude>
               <exclude>**/config/client/*CfgClient*.class</exclude>
               <exclude>**/config/server/*Cfg*.class</exclude>
               <exclude>**/config/meta/*.class</exclude>
             </excludes>
-          </instrumentation>
         </configuration>
       </plugin>
     </plugins>
@@ -200,15 +198,6 @@
             </reports>
           </reportSet>
         </reportSets>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-javadoc-plugin</artifactId>
-        <configuration>
-          <links>
-            <link>http://commons.forgerock.org/i18n-framework/i18n-core/apidocs</link>
-          </links>
-        </configuration>
       </plugin>
     </plugins>
   </reporting>

--- a/opendj-core/pom.xml
+++ b/opendj-core/pom.xml
@@ -13,14 +13,14 @@
   information: "Portions Copyright [year] [name of copyright owner]".
 
   Copyright 2011-2016 ForgeRock AS.
-  Portions Copyright 2018-2021 Wren Security.
+  Portions Copyright 2018-2022 Wren Security.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <artifactId>opendj-parent</artifactId>
-        <groupId>org.forgerock.opendj</groupId>
+        <artifactId>opendj-project</artifactId>
+        <groupId>org.wrensecurity.wrends</groupId>
         <version>4.0.0-M4-SNAPSHOT</version>
     </parent>
 
@@ -269,7 +269,7 @@
                             <includeDependencySources>true</includeDependencySources>
                             <includeTransitiveDependencySources>true</includeTransitiveDependencySources>
                             <dependencySourceIncludes>
-                                <dependencySourceInclude>org.forgerock.*:*</dependencySourceInclude>
+                                <dependencySourceInclude>org.wrensecurity.*:*</dependencySourceInclude>
                             </dependencySourceIncludes>
                             <excludePackageNames>com.*:*.internal</excludePackageNames>
                             <groups>
@@ -313,16 +313,6 @@
                         </reports>
                     </reportSet>
                 </reportSets>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <configuration>
-                    <links>
-                        <link>http://commons.forgerock.org/i18n-framework/i18n-core/apidocs</link>
-                    </links>
-                </configuration>
             </plugin>
         </plugins>
     </reporting>

--- a/opendj-doc-generated-ref/pom.xml
+++ b/opendj-doc-generated-ref/pom.xml
@@ -13,14 +13,14 @@
   ~ information: "Portions Copyright [year] [name of copyright owner]".
   ~
   ~ Copyright 2016 ForgeRock AS.
-  ~ Portions Copyright 2018-2021 Wren Security.
+  ~ Portions Copyright 2018-2022 Wren Security.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <artifactId>opendj-parent</artifactId>
-        <groupId>org.forgerock.opendj</groupId>
+        <artifactId>opendj-project</artifactId>
+        <groupId>org.wrensecurity.wrends</groupId>
         <version>4.0.0-M4-SNAPSHOT</version>
     </parent>
 
@@ -50,14 +50,14 @@
                         <configuration>
                             <artifactItems>
                                 <artifactItem>
-                                    <groupId>org.forgerock.opendj</groupId>
+                                    <groupId>org.wrensecurity.wrends</groupId>
                                     <artifactId>opendj-core</artifactId>
                                     <version>${project.version}</version>
                                     <classifier>sources</classifier>
                                 </artifactItem>
 
                                 <artifactItem>
-                                    <groupId>org.forgerock.opendj</groupId>
+                                    <groupId>org.wrensecurity.wrends</groupId>
                                     <artifactId>opendj-server-legacy</artifactId>
                                     <version>${project.version}</version>
                                     <type>zip</type>
@@ -66,7 +66,7 @@
                                 </artifactItem>
 
                                 <artifactItem>
-                                    <groupId>org.forgerock.opendj</groupId>
+                                    <groupId>org.wrensecurity.wrends</groupId>
                                     <artifactId>opendj-ldap-toolkit</artifactId>
                                     <version>${project.version}</version>
                                     <type>zip</type>
@@ -97,7 +97,7 @@
             </plugin>
 
             <plugin>
-                <groupId>org.forgerock.opendj</groupId>
+                <groupId>org.wrensecurity.wrends</groupId>
                 <artifactId>opendj-doc-maven-plugin</artifactId>
 
                 <executions>
@@ -366,7 +366,7 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.forgerock.opendj</groupId>
+                        <groupId>org.wrensecurity.wrends</groupId>
                         <artifactId>opendj-doc-maven-plugin</artifactId>
 
                         <executions>
@@ -377,7 +377,7 @@
                                 </goals>
                                 <phase>generate-sources</phase>
                                 <configuration>
-                                    <archiveDir>${project.build.directory}/opendj</archiveDir>
+                                    <archiveDir>${project.build.directory}/wrends</archiveDir>
                                     <mode>SERVER</mode>
                                     <extendedClasspath>
                                         ${project.build.directory}/dependency/freemarker-${freemarker.version}.jar
@@ -581,9 +581,9 @@
 
                     <!-- Format man pages -->
                     <plugin>
-                        <groupId>org.forgerock.commons</groupId>
+                        <groupId>org.wrensecurity.commons</groupId>
                         <artifactId>forgerock-doc-maven-plugin</artifactId>
-                        <version>${forgerock-doc-plugin.version}</version>
+                        <version>22.4.0-SNAPSHOT</version>
                         <executions>
                             <execution>
                                 <id>build-man-pages</id>

--- a/opendj-doc-maven-plugin/pom.xml
+++ b/opendj-doc-maven-plugin/pom.xml
@@ -13,14 +13,14 @@
   information: "Portions Copyright [year] [name of copyright owner]".
 
   Copyright 2015-2016 ForgeRock AS.
-  Portions Copyright 2018 Wren Security.
+  Portions Copyright 2018-2022 Wren Security.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <artifactId>opendj-parent</artifactId>
-        <groupId>org.forgerock.opendj</groupId>
+        <artifactId>opendj-project</artifactId>
+        <groupId>org.wrensecurity.wrends</groupId>
         <version>4.0.0-M4-SNAPSHOT</version>
     </parent>
 
@@ -36,7 +36,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.forgerock.opendj</groupId>
+            <groupId>org.wrensecurity.wrends</groupId>
             <artifactId>opendj-core</artifactId>
         </dependency>
 

--- a/opendj-doc-maven-plugin/src/main/java/org/forgerock/opendj/maven/doc/GenerateRefEntriesMojo.java
+++ b/opendj-doc-maven-plugin/src/main/java/org/forgerock/opendj/maven/doc/GenerateRefEntriesMojo.java
@@ -64,7 +64,7 @@ public final class GenerateRefEntriesMojo extends AbstractMojo {
     private MavenProject project;
 
     /** Archive directory of the artifact (server or toolkit) to use to generate documentation. */
-    @Parameter(property = "docArchiveDir", defaultValue = "${project.build.directory}/opendj", required = true)
+    @Parameter(property = "docArchiveDir", defaultValue = "${project.build.directory}/wrends", required = true)
     private String archiveDir;
 
     /** Whether the plugin should use the server or the toolkit classpath. */

--- a/opendj-dsml-servlet/pom.xml
+++ b/opendj-dsml-servlet/pom.xml
@@ -13,14 +13,14 @@
   information: "Portions Copyright [year] [name of copyright owner]".
 
   Copyright 2015-2016 ForgeRock AS.
-  Portions Copyright 2017-2021 Wren Security.
+  Portions Copyright 2017-2022 Wren Security.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.forgerock.opendj</groupId>
-        <artifactId>opendj-parent</artifactId>
+        <groupId>org.wrensecurity.wrends</groupId>
+        <artifactId>opendj-project</artifactId>
         <version>4.0.0-M4-SNAPSHOT</version>
     </parent>
 
@@ -63,18 +63,18 @@
 
         <!-- Wren:DS SDK dependency -->
         <dependency>
-            <groupId>org.forgerock.opendj</groupId>
+            <groupId>org.wrensecurity.wrends</groupId>
             <artifactId>opendj-core</artifactId>
         </dependency>
 
         <!-- Wren:DS Server dependencies -->
         <dependency>
-            <groupId>org.forgerock.opendj</groupId>
+            <groupId>org.wrensecurity.wrends</groupId>
             <artifactId>opendj-config</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>org.forgerock.opendj</groupId>
+            <groupId>org.wrensecurity.wrends</groupId>
             <artifactId>${opendj.server.module.name}</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
@@ -101,7 +101,7 @@
                             <artifactItems>
                                 <!-- Copy and rename opendj main jar -->
                                 <artifactItem>
-                                    <groupId>org.forgerock.opendj</groupId>
+                                    <groupId>org.wrensecurity.wrends</groupId>
                                     <artifactId>${opendj.server.module.name}</artifactId>
                                     <version>${project.version}</version>
                                     <outputDirectory>${project.build.directory}/${opendj.jars.folder}</outputDirectory>
@@ -110,7 +110,7 @@
 
                                 <!-- Copy and rename opendj localized jars -->
                                 <artifactItem>
-                                    <groupId>org.forgerock.opendj</groupId>
+                                    <groupId>org.wrensecurity.wrends</groupId>
                                     <artifactId>${opendj.server.module.name}</artifactId>
                                     <version>${project.version}</version>
                                     <classifier>${localized.jars.classifier}-ca_ES</classifier>
@@ -119,7 +119,7 @@
                                 </artifactItem>
 
                                 <artifactItem>
-                                    <groupId>org.forgerock.opendj</groupId>
+                                    <groupId>org.wrensecurity.wrends</groupId>
                                     <artifactId>${opendj.server.module.name}</artifactId>
                                     <version>${project.version}</version>
                                     <classifier>${localized.jars.classifier}-de</classifier>
@@ -128,7 +128,7 @@
                                 </artifactItem>
 
                                 <artifactItem>
-                                    <groupId>org.forgerock.opendj</groupId>
+                                    <groupId>org.wrensecurity.wrends</groupId>
                                     <artifactId>${opendj.server.module.name}</artifactId>
                                     <version>${project.version}</version>
                                     <classifier>${localized.jars.classifier}-es</classifier>
@@ -137,7 +137,7 @@
                                 </artifactItem>
 
                                 <artifactItem>
-                                    <groupId>org.forgerock.opendj</groupId>
+                                    <groupId>org.wrensecurity.wrends</groupId>
                                     <artifactId>${opendj.server.module.name}</artifactId>
                                     <version>${project.version}</version>
                                     <classifier>${localized.jars.classifier}-fr</classifier>
@@ -146,7 +146,7 @@
                                 </artifactItem>
 
                                 <artifactItem>
-                                    <groupId>org.forgerock.opendj</groupId>
+                                    <groupId>org.wrensecurity.wrends</groupId>
                                     <artifactId>${opendj.server.module.name}</artifactId>
                                     <version>${project.version}</version>
                                     <classifier>${localized.jars.classifier}-ja</classifier>
@@ -155,7 +155,7 @@
                                 </artifactItem>
 
                                 <artifactItem>
-                                    <groupId>org.forgerock.opendj</groupId>
+                                    <groupId>org.wrensecurity.wrends</groupId>
                                     <artifactId>${opendj.server.module.name}</artifactId>
                                     <version>${project.version}</version>
                                     <classifier>${localized.jars.classifier}-ko</classifier>
@@ -164,7 +164,7 @@
                                 </artifactItem>
 
                                 <artifactItem>
-                                    <groupId>org.forgerock.opendj</groupId>
+                                    <groupId>org.wrensecurity.wrends</groupId>
                                     <artifactId>${opendj.server.module.name}</artifactId>
                                     <version>${project.version}</version>
                                     <classifier>${localized.jars.classifier}-pl</classifier>
@@ -173,7 +173,7 @@
                                 </artifactItem>
 
                                 <artifactItem>
-                                    <groupId>org.forgerock.opendj</groupId>
+                                    <groupId>org.wrensecurity.wrends</groupId>
                                     <artifactId>${opendj.server.module.name}</artifactId>
                                     <version>${project.version}</version>
                                     <classifier>${localized.jars.classifier}-zh_CN</classifier>
@@ -182,7 +182,7 @@
                                 </artifactItem>
 
                                 <artifactItem>
-                                    <groupId>org.forgerock.opendj</groupId>
+                                    <groupId>org.wrensecurity.wrends</groupId>
                                     <artifactId>${opendj.server.module.name}</artifactId>
                                     <version>${project.version}</version>
                                     <classifier>${localized.jars.classifier}-zh_TW</classifier>

--- a/opendj-embedded-server-examples/pom.xml
+++ b/opendj-embedded-server-examples/pom.xml
@@ -13,14 +13,14 @@
   information: "Portions Copyright [year] [name of copyright owner]".
 
   Copyright 2016 ForgeRock AS.
-  Portions Copyright 2017-2021 Wren Security.
+  Portions Copyright 2017-2022 Wren Security.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <artifactId>opendj-parent</artifactId>
-        <groupId>org.forgerock.opendj</groupId>
+        <artifactId>opendj-project</artifactId>
+        <groupId>org.wrensecurity.wrends</groupId>
         <version>4.0.0-M4-SNAPSHOT</version>
     </parent>
 
@@ -30,7 +30,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.forgerock.opendj</groupId>
+            <groupId>org.wrensecurity.wrends</groupId>
             <artifactId>opendj-server-legacy</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -65,16 +65,6 @@
 
     <reporting>
         <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <configuration>
-                    <links>
-                        <link>http://commons.forgerock.org/i18n-framework/i18n-core/apidocs</link>
-                    </links>
-                </configuration>
-            </plugin>
-
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jxr-plugin</artifactId>

--- a/opendj-grizzly/pom.xml
+++ b/opendj-grizzly/pom.xml
@@ -13,14 +13,14 @@
   information: "Portions Copyright [year] [name of copyright owner]".
 
   Copyright 2013-2016 ForgeRock AS.
-  Portions Copyright 2018-2021 Wren Security.
+  Portions Copyright 2018-2022 Wren Security.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <artifactId>opendj-parent</artifactId>
-        <groupId>org.forgerock.opendj</groupId>
+        <artifactId>opendj-project</artifactId>
+        <groupId>org.wrensecurity.wrends</groupId>
         <version>4.0.0-M4-SNAPSHOT</version>
     </parent>
 
@@ -36,12 +36,12 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.forgerock.opendj</groupId>
+            <groupId>org.wrensecurity.wrends</groupId>
             <artifactId>opendj-core</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>org.forgerock.opendj</groupId>
+            <groupId>org.wrensecurity.wrends</groupId>
             <artifactId>opendj-core</artifactId>
             <type>test-jar</type>
             <scope>test</scope>
@@ -130,16 +130,6 @@
                         </reports>
                     </reportSet>
                 </reportSets>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <configuration>
-                    <links>
-                        <link>http://commons.forgerock.org/i18n-framework/i18n-core/apidocs</link>
-                    </links>
-                </configuration>
             </plugin>
         </plugins>
     </reporting>

--- a/opendj-ldap-sdk-examples/pom.xml
+++ b/opendj-ldap-sdk-examples/pom.xml
@@ -13,14 +13,14 @@
   information: "Portions Copyright [year] [name of copyright owner]".
 
   Copyright 2011-2016 ForgeRock AS.
-  Portions Copyright 2018 Wren Security.
+  Portions Copyright 2018-2022 Wren Security.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <artifactId>opendj-parent</artifactId>
-        <groupId>org.forgerock.opendj</groupId>
+        <artifactId>opendj-project</artifactId>
+        <groupId>org.wrensecurity.wrends</groupId>
         <version>4.0.0-M4-SNAPSHOT</version>
     </parent>
 
@@ -30,12 +30,12 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.forgerock.opendj</groupId>
+            <groupId>org.wrensecurity.wrends</groupId>
             <artifactId>opendj-core</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>org.forgerock.opendj</groupId>
+            <groupId>org.wrensecurity.wrends</groupId>
             <artifactId>opendj-grizzly</artifactId>
         </dependency>
 
@@ -73,16 +73,6 @@
 
     <reporting>
         <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <configuration>
-                    <links>
-                        <link>http://commons.forgerock.org/i18n-framework/i18n-core/apidocs</link>
-                    </links>
-                </configuration>
-            </plugin>
-
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jxr-plugin</artifactId>

--- a/opendj-ldap-toolkit/pom.xml
+++ b/opendj-ldap-toolkit/pom.xml
@@ -13,14 +13,14 @@
   information: "Portions Copyright [year] [name of copyright owner]".
 
   Copyright 2011-2016 ForgeRock AS.
-  Portions Copyright 2018-2021 Wren Security.
+  Portions Copyright 2018-2022 Wren Security.
  -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <artifactId>opendj-parent</artifactId>
-        <groupId>org.forgerock.opendj</groupId>
+        <artifactId>opendj-project</artifactId>
+        <groupId>org.wrensecurity.wrends</groupId>
         <version>4.0.0-M4-SNAPSHOT</version>
     </parent>
 
@@ -43,12 +43,12 @@
         </dependency>
 
         <dependency>
-            <groupId>org.forgerock.opendj</groupId>
+            <groupId>org.wrensecurity.wrends</groupId>
             <artifactId>opendj-core</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>org.forgerock.opendj</groupId>
+            <groupId>org.wrensecurity.wrends</groupId>
             <artifactId>opendj-grizzly</artifactId>
         </dependency>
 
@@ -68,12 +68,12 @@
         </dependency>
 
         <dependency>
-            <groupId>org.forgerock.opendj</groupId>
+            <groupId>org.wrensecurity.wrends</groupId>
             <artifactId>opendj-cli</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>org.forgerock.opendj</groupId>
+            <groupId>org.wrensecurity.wrends</groupId>
             <artifactId>opendj-core</artifactId>
             <type>test-jar</type>
             <scope>test</scope>

--- a/opendj-legacy/pom.xml
+++ b/opendj-legacy/pom.xml
@@ -13,13 +13,13 @@
   information: "Portions Copyright [year] [name of copyright owner]".
 
   Copyright 2014-2016 ForgeRock AS.
-  Portions Copyright 2017-2018 Wren Security.
+  Portions Copyright 2017-2022 Wren Security.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.forgerock.opendj</groupId>
-    <artifactId>opendj-parent</artifactId>
+    <groupId>org.wrensecurity.wrends</groupId>
+    <artifactId>opendj-project</artifactId>
     <version>4.0.0-M4-SNAPSHOT</version>
   </parent>
   <artifactId>opendj-legacy</artifactId>

--- a/opendj-maven-plugin/pom.xml
+++ b/opendj-maven-plugin/pom.xml
@@ -13,42 +13,44 @@
   information: "Portions Copyright [year] [name of copyright owner]".
 
   Copyright 2015-2016 ForgeRock AS.
-  Portions Copyright 2017-2018 Wren Security.
+  Portions Copyright 2017-2022 Wren Security.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
-  <parent>
-    <groupId>org.forgerock.opendj</groupId>
-    <artifactId>opendj-parent</artifactId>
-    <version>4.0.0-M4-SNAPSHOT</version>
-  </parent>
+    <modelVersion>4.0.0</modelVersion>
 
-  <artifactId>opendj-maven-plugin</artifactId>
-  <name>Wren:DS Maven Plugin</name>
-  <description>
-    Set of build tools for Wren:DS project.
-  </description>
-  <packaging>maven-plugin</packaging>
+    <parent>
+        <groupId>org.wrensecurity.wrends</groupId>
+        <artifactId>opendj-project</artifactId>
+        <version>4.0.0-M4-SNAPSHOT</version>
+    </parent>
 
-  <properties>
-    <mavenVersion>3.0.4</mavenVersion>
-  </properties>
+    <artifactId>opendj-maven-plugin</artifactId>
 
-  <dependencies>
-    <dependency>
-        <groupId>org.wrensecurity.commons</groupId>
-        <artifactId>forgerock-util</artifactId>
-    </dependency>
-    <dependency>
-        <groupId>org.twdata.maven</groupId>
-        <artifactId>mojo-executor</artifactId>
-        <version>2.2.0</version>
-    </dependency>
-    <dependency>
-        <groupId>org.apache.maven.plugin-tools</groupId>
-        <artifactId>maven-plugin-annotations</artifactId>
-        <version>3.2</version>
-        <scope>provided</scope>
-    </dependency>
-  </dependencies>
+    <name>Wren:DS Maven Plugin</name>
+    <description>
+        Set of build tools for Wren:DS project.
+    </description>
+    <packaging>maven-plugin</packaging>
+
+    <properties>
+        <mavenVersion>3.0.4</mavenVersion>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.wrensecurity.commons</groupId>
+            <artifactId>forgerock-util</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.twdata.maven</groupId>
+            <artifactId>mojo-executor</artifactId>
+            <version>2.2.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.plugin-tools</groupId>
+            <artifactId>maven-plugin-annotations</artifactId>
+            <version>3.2</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
 </project>

--- a/opendj-openidm-account-change-notification-handler/pom.xml
+++ b/opendj-openidm-account-change-notification-handler/pom.xml
@@ -13,14 +13,14 @@
   information: "Portions Copyright [year] [name of copyright owner]".
 
   Copyright 2014-2016 ForgeRock AS.
-  Portions Copyright 2018 Wren Security.
+  Portions Copyright 2018-2022 Wren Security.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.forgerock.opendj</groupId>
-    <artifactId>opendj-parent</artifactId>
+    <groupId>org.wrensecurity.wrends</groupId>
+    <artifactId>opendj-project</artifactId>
     <version>4.0.0-M4-SNAPSHOT</version>
   </parent>
 
@@ -33,16 +33,16 @@
   </description>
 
   <packaging>jar</packaging>
-  
+
   <dependencies>
     <dependency>
-      <groupId>org.forgerock.opendj</groupId>
+      <groupId>org.wrensecurity.wrends</groupId>
       <artifactId>opendj-core</artifactId>
       <scope>provided</scope>
     </dependency>
 
     <dependency>
-      <groupId>org.forgerock.opendj</groupId>
+      <groupId>org.wrensecurity.wrends</groupId>
       <artifactId>opendj-config</artifactId>
       <scope>provided</scope>
     </dependency>
@@ -60,7 +60,7 @@
     </dependency>
 
     <dependency>
-      <groupId>org.forgerock.opendj</groupId>
+      <groupId>org.wrensecurity.wrends</groupId>
       <artifactId>opendj-server-legacy</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>
@@ -82,7 +82,7 @@
       <artifactId>chf-client-apache-async</artifactId>
     </dependency>
   </dependencies>
-  
+
   <build>
     <plugins>
       <plugin>
@@ -109,7 +109,7 @@
       </plugin>
 
       <plugin>
-        <groupId>org.forgerock.opendj</groupId>
+        <groupId>org.wrensecurity.wrends</groupId>
         <artifactId>opendj-maven-plugin</artifactId>
 
         <executions>
@@ -191,7 +191,7 @@
       </plugin>
     </plugins>
   </build>
-  
+
   <reporting>
     <plugins>
       <plugin>

--- a/opendj-packages/opendj-deb/opendj-deb-oem/pom.xml
+++ b/opendj-packages/opendj-deb/opendj-deb-oem/pom.xml
@@ -19,7 +19,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.forgerock.opendj</groupId>
+        <groupId>org.wrensecurity.wrends</groupId>
         <artifactId>opendj-deb</artifactId>
         <version>4.0.0-M4-SNAPSHOT</version>
     </parent>
@@ -57,7 +57,7 @@
                         <configuration>
                             <artifactItems>
                                 <artifactItem>
-                                    <groupId>org.forgerock.opendj</groupId>
+                                    <groupId>org.wrensecurity.wrends</groupId>
                                     <artifactId>opendj-zip-oem</artifactId>
                                     <version>${project.version}</version>
                                     <type>zip</type>

--- a/opendj-packages/opendj-deb/opendj-deb-standard/pom.xml
+++ b/opendj-packages/opendj-deb/opendj-deb-standard/pom.xml
@@ -19,7 +19,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.forgerock.opendj</groupId>
+        <groupId>org.wrensecurity.wrends</groupId>
         <artifactId>opendj-deb</artifactId>
         <version>4.0.0-M4-SNAPSHOT</version>
     </parent>

--- a/opendj-packages/opendj-deb/pom.xml
+++ b/opendj-packages/opendj-deb/pom.xml
@@ -21,7 +21,7 @@
     <packaging>pom</packaging>
 
     <parent>
-        <groupId>org.forgerock.opendj</groupId>
+        <groupId>org.wrensecurity.wrends</groupId>
         <artifactId>opendj-packages</artifactId>
         <version>4.0.0-M4-SNAPSHOT</version>
     </parent>
@@ -53,9 +53,9 @@
         <deb.prefix>/opt/${product.name.lowercase}</deb.prefix>
         <deb.docprefix>/usr/share/doc/${product.name.lowercase}</deb.docprefix>
         <deb.release>1</deb.release>
-        <deb.maintainer>opendj@forgerock.org</deb.maintainer>
+        <deb.maintainer>info@wrensecurity.org</deb.maintainer>
         <manpage.dir>${project.build.directory}/dependency/man</manpage.dir>
-        <deb.doc.homepage.url>http://opendj.forgerock.org/</deb.doc.homepage.url>
+        <deb.doc.homepage.url>https://wrensecurity.org/</deb.doc.homepage.url>
         <deb.product.name />
         <deb.product.name.lowercase />
         <deb.resources.path />
@@ -78,7 +78,7 @@
                             <configuration>
                                 <artifactItems>
                                     <artifactItem>
-                                        <groupId>org.forgerock.opendj</groupId>
+                                        <groupId>org.wrensecurity.wrends</groupId>
                                         <artifactId>opendj-doc-generated-ref</artifactId>
                                         <version>${project.version}</version>
                                         <outputDirectory>${project.build.directory}/dependency/man</outputDirectory>

--- a/opendj-packages/opendj-msi/opendj-msi-standard/pom.xml
+++ b/opendj-packages/opendj-msi/opendj-msi-standard/pom.xml
@@ -19,7 +19,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.forgerock.opendj</groupId>
+        <groupId>org.wrensecurity.wrends</groupId>
         <artifactId>opendj-msi</artifactId>
         <version>4.0.0-M4-SNAPSHOT</version>
     </parent>

--- a/opendj-packages/opendj-msi/pom.xml
+++ b/opendj-packages/opendj-msi/pom.xml
@@ -19,7 +19,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.forgerock.opendj</groupId>
+        <groupId>org.wrensecurity.wrends</groupId>
         <artifactId>opendj-packages</artifactId>
         <version>4.0.0-M4-SNAPSHOT</version>
     </parent>

--- a/opendj-packages/opendj-rpm/opendj-rpm-oem/pom.xml
+++ b/opendj-packages/opendj-rpm/opendj-rpm-oem/pom.xml
@@ -19,7 +19,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.forgerock.opendj</groupId>
+        <groupId>org.wrensecurity.wrends</groupId>
         <artifactId>opendj-rpm</artifactId>
         <version>4.0.0-M4-SNAPSHOT</version>
     </parent>
@@ -57,7 +57,7 @@
                         <configuration>
                             <artifactItems>
                                 <artifactItem>
-                                    <groupId>org.forgerock.opendj</groupId>
+                                    <groupId>org.wrensecurity.wrends</groupId>
                                     <artifactId>opendj-zip-oem</artifactId>
                                     <version>${project.version}</version>
                                     <type>zip</type>

--- a/opendj-packages/opendj-rpm/opendj-rpm-standard/pom.xml
+++ b/opendj-packages/opendj-rpm/opendj-rpm-standard/pom.xml
@@ -19,7 +19,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.forgerock.opendj</groupId>
+        <groupId>org.wrensecurity.wrends</groupId>
         <artifactId>opendj-rpm</artifactId>
         <version>4.0.0-M4-SNAPSHOT</version>
     </parent>

--- a/opendj-packages/opendj-rpm/pom.xml
+++ b/opendj-packages/opendj-rpm/pom.xml
@@ -19,7 +19,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.forgerock.opendj</groupId>
+        <groupId>org.wrensecurity.wrends</groupId>
         <artifactId>opendj-packages</artifactId>
         <version>4.0.0-M4-SNAPSHOT</version>
     </parent>
@@ -52,7 +52,7 @@
     <properties>
         <rpm.prefix>/opt/${product.name.lowercase}</rpm.prefix>
         <manpage.dir>${project.build.directory}/dependency/man</manpage.dir>
-        <doc.homepage.url>http://opendj.forgerock.org/</doc.homepage.url>
+        <doc.homepage.url>https://wrensecurity.org/</doc.homepage.url>
         <rpm.license />
         <rpm.product.name />
         <rpm.product.name.lowercase />
@@ -78,7 +78,7 @@
                             <configuration>
                                 <artifactItems>
                                     <artifactItem>
-                                        <groupId>org.forgerock.opendj</groupId>
+                                        <groupId>org.wrensecurity.wrends</groupId>
                                         <artifactId>opendj-doc-generated-ref</artifactId>
                                         <version>${project.version}</version>
                                         <outputDirectory>${project.build.directory}/dependency/man</outputDirectory>

--- a/opendj-packages/opendj-svr4/opendj-svr4-standard/pom.xml
+++ b/opendj-packages/opendj-svr4/opendj-svr4-standard/pom.xml
@@ -19,7 +19,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.forgerock.opendj</groupId>
+        <groupId>org.wrensecurity.wrends</groupId>
         <artifactId>opendj-svr4</artifactId>
         <version>4.0.0-M4-SNAPSHOT</version>
     </parent>

--- a/opendj-packages/opendj-svr4/pom.xml
+++ b/opendj-packages/opendj-svr4/pom.xml
@@ -19,7 +19,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.forgerock.opendj</groupId>
+        <groupId>org.wrensecurity.wrends</groupId>
         <artifactId>opendj-packages</artifactId>
         <version>4.0.0-M4-SNAPSHOT</version>
     </parent>

--- a/opendj-packages/opendj-zip/opendj-zip-oem/pom.xml
+++ b/opendj-packages/opendj-zip/opendj-zip-oem/pom.xml
@@ -19,7 +19,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.forgerock.opendj</groupId>
+        <groupId>org.wrensecurity.wrends</groupId>
         <artifactId>opendj-zip</artifactId>
         <version>4.0.0-M4-SNAPSHOT</version>
     </parent>
@@ -51,7 +51,7 @@
           ! our classpath to build boostrap.jar and boostrap-client.jar
         -->
         <dependency>
-            <groupId>org.forgerock.opendj</groupId>
+            <groupId>org.wrensecurity.wrends</groupId>
             <artifactId>opendj-server-legacy</artifactId>
             <version>${project.version}</version>
             <exclusions>
@@ -74,7 +74,7 @@
         <plugins>
             <!-- Generates bootstrap.jar and bootstrap-client.jar for OEM archive edition --> 
             <plugin>
-                <groupId>org.forgerock.opendj</groupId>
+                <groupId>org.wrensecurity.wrends</groupId>
                 <artifactId>opendj-maven-plugin</artifactId>
             </plugin>
 

--- a/opendj-packages/opendj-zip/pom.xml
+++ b/opendj-packages/opendj-zip/pom.xml
@@ -19,7 +19,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.forgerock.opendj</groupId>
+        <groupId>org.wrensecurity.wrends</groupId>
         <artifactId>opendj-packages</artifactId>
         <version>4.0.0-M4-SNAPSHOT</version>
     </parent>

--- a/opendj-packages/pom.xml
+++ b/opendj-packages/pom.xml
@@ -13,14 +13,14 @@
   information: "Portions Copyright [year] [name of copyright owner]".
 
   Copyright 2015-2016 ForgeRock AS.
-  Portions Copyright 2018 Wren Security.
+  Portions Copyright 2018-2022 Wren Security.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.forgerock.opendj</groupId>
-        <artifactId>opendj-parent</artifactId>
+        <groupId>org.wrensecurity.wrends</groupId>
+        <artifactId>opendj-project</artifactId>
         <version>4.0.0-M4-SNAPSHOT</version>
     </parent>
 
@@ -102,7 +102,7 @@
                             <configuration>
                                 <artifactItems>
                                     <artifactItem>
-                                        <groupId>org.forgerock.opendj</groupId>
+                                        <groupId>org.wrensecurity.wrends</groupId>
                                         <artifactId>opendj-server-legacy</artifactId>
                                         <version>${project.version}</version>
                                         <type>zip</type>

--- a/opendj-rest2ldap-servlet/pom.xml
+++ b/opendj-rest2ldap-servlet/pom.xml
@@ -13,13 +13,13 @@
   information: "Portions Copyright [year] [name of copyright owner]".
 
   Copyright 2013-2016 ForgeRock AS.
-  Portions Copyright 2017-2018 Wren Security.
+  Portions Copyright 2017-2022 Wren Security.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.forgerock.opendj</groupId>
-    <artifactId>opendj-parent</artifactId>
+    <groupId>org.wrensecurity.wrends</groupId>
+    <artifactId>opendj-project</artifactId>
     <version>4.0.0-M4-SNAPSHOT</version>
   </parent>
 
@@ -47,12 +47,12 @@
     </dependency>
 
     <dependency>
-      <groupId>org.forgerock.opendj</groupId>
+      <groupId>org.wrensecurity.wrends</groupId>
       <artifactId>opendj-rest2ldap</artifactId>
     </dependency>
 
     <dependency>
-      <groupId>org.forgerock.opendj</groupId>
+      <groupId>org.wrensecurity.wrends</groupId>
       <artifactId>opendj-grizzly</artifactId>
     </dependency>
   </dependencies>

--- a/opendj-rest2ldap/pom.xml
+++ b/opendj-rest2ldap/pom.xml
@@ -13,14 +13,14 @@
    information: "Portions Copyright [year] [name of copyright owner]".
 
    Copyright 2012-2016 ForgeRock AS.
-   Portions Copyright 2018-2021 Wren Security.
+   Portions Copyright 2018-2022 Wren Security.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <artifactId>opendj-parent</artifactId>
-        <groupId>org.forgerock.opendj</groupId>
+        <artifactId>opendj-project</artifactId>
+        <groupId>org.wrensecurity.wrends</groupId>
         <version>4.0.0-M4-SNAPSHOT</version>
     </parent>
 
@@ -38,7 +38,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.forgerock.opendj</groupId>
+            <groupId>org.wrensecurity.wrends</groupId>
             <artifactId>opendj-core</artifactId>
         </dependency>
 

--- a/opendj-server-example-plugin/pom.xml
+++ b/opendj-server-example-plugin/pom.xml
@@ -13,13 +13,13 @@
   information: "Portions Copyright [year] [name of copyright owner]".
 
   Copyright 2014-2016 ForgeRock AS.
-  Portions Copyright 2017-2018 Wren Security.
+  Portions Copyright 2017-2022 Wren Security.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.forgerock.opendj</groupId>
-    <artifactId>opendj-parent</artifactId>
+    <groupId>org.wrensecurity.wrends</groupId>
+    <artifactId>opendj-project</artifactId>
     <version>4.0.0-M4-SNAPSHOT</version>
   </parent>
   <artifactId>opendj-server-example-plugin</artifactId>
@@ -30,7 +30,7 @@
   <packaging>jar</packaging>
   <dependencies>
     <dependency>
-      <groupId>org.forgerock.opendj</groupId>
+      <groupId>org.wrensecurity.wrends</groupId>
       <artifactId>opendj-server-legacy</artifactId>
       <version>${project.version}</version>
     </dependency>
@@ -63,7 +63,7 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.forgerock.opendj</groupId>
+        <groupId>org.wrensecurity.wrends</groupId>
         <artifactId>opendj-maven-plugin</artifactId>
         <executions>
           <execution>

--- a/opendj-server-legacy/pom.xml
+++ b/opendj-server-legacy/pom.xml
@@ -13,14 +13,14 @@
   information: "Portions Copyright [year] [name of copyright owner]".
 
   Copyright 2011-2016 ForgeRock AS.
-  Portions Copyright 2017-2021 Wren Security.
+  Portions Copyright 2017-2022 Wren Security.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.forgerock.opendj</groupId>
-    <artifactId>opendj-parent</artifactId>
+    <groupId>org.wrensecurity.wrends</groupId>
+    <artifactId>opendj-project</artifactId>
     <version>4.0.0-M4-SNAPSHOT</version>
   </parent>
   <artifactId>opendj-server-legacy</artifactId>
@@ -39,7 +39,7 @@
     <!-- Product information properties -->
     <patchFixIds />
     <isDebugBuild>false</isDebugBuild>
-    <docHomepageUrl>http://opendj.forgerock.org/</docHomepageUrl>
+    <docHomepageUrl>https://opendj.forgerock.org/</docHomepageUrl>
     <docWikiUrl>http://opendj.forgerock.org/docs.html</docWikiUrl>
     <docGuideRefUrl>http://opendj.forgerock.org/opendj-server-legacy/doc/bootstrap/admin-guide/</docGuideRefUrl>
     <docGuideAdminUrl>http://opendj.forgerock.org/opendj-server-legacy/doc/bootstrap/admin-guide/</docGuideAdminUrl>
@@ -61,12 +61,12 @@
   <dependencies>
     <!-- ForgeRock libraries -->
     <dependency>
-      <groupId>org.forgerock.opendj</groupId>
+      <groupId>org.wrensecurity.wrends</groupId>
       <artifactId>opendj-cli</artifactId>
     </dependency>
 
     <dependency>
-      <groupId>org.forgerock.opendj</groupId>
+      <groupId>org.wrensecurity.wrends</groupId>
       <artifactId>opendj-rest2ldap</artifactId>
     </dependency>
 
@@ -76,12 +76,12 @@
     </dependency>
 
     <dependency>
-      <groupId>org.forgerock.opendj</groupId>
+      <groupId>org.wrensecurity.wrends</groupId>
       <artifactId>opendj-config</artifactId>
     </dependency>
 
     <dependency>
-      <groupId>org.forgerock.opendj</groupId>
+      <groupId>org.wrensecurity.wrends</groupId>
       <artifactId>opendj-config</artifactId>
       <version>${project.version}</version>
       <type>test-jar</type>
@@ -89,12 +89,12 @@
     </dependency>
 
     <dependency>
-      <groupId>org.forgerock.opendj</groupId>
+      <groupId>org.wrensecurity.wrends</groupId>
       <artifactId>opendj-server</artifactId>
     </dependency>
 
     <dependency>
-      <groupId>org.forgerock.opendj</groupId>
+      <groupId>org.wrensecurity.wrends</groupId>
       <artifactId>opendj-ldap-toolkit</artifactId>
       <version>${project.version}</version>
     </dependency>
@@ -417,7 +417,7 @@
 
       <plugin>
         <?m2e ignore?>
-        <groupId>org.forgerock.opendj</groupId>
+        <groupId>org.wrensecurity.wrends</groupId>
         <artifactId>opendj-maven-plugin</artifactId>
 
         <executions>
@@ -900,7 +900,7 @@
             <configuration>
               <artifactItems>
                 <artifactItem>
-                  <groupId>org.forgerock.opendj</groupId>
+                  <groupId>org.wrensecurity.wrends</groupId>
                   <artifactId>opendj-ldap-toolkit</artifactId>
                   <version>${project.version}</version>
                   <type>zip</type>
@@ -1032,14 +1032,6 @@
           <arguments>-Penforce -Dopendmk.lib.dir=${opendmk.lib.dir}</arguments>
         </configuration>
       </plugin>
-
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>cobertura-maven-plugin</artifactId>
-        <configuration>
-            <skip>true</skip>
-        </configuration>
-        </plugin>
     </plugins>
   </build>
 

--- a/opendj-server/pom.xml
+++ b/opendj-server/pom.xml
@@ -13,13 +13,13 @@
   information: "Portions Copyright [year] [name of copyright owner]".
 
   Copyright 2013-2016 ForgeRock AS.
-  Portions Copyright 2017-2021 Wren Security.
+  Portions Copyright 2017-2022 Wren Security.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.forgerock.opendj</groupId>
-    <artifactId>opendj-parent</artifactId>
+    <groupId>org.wrensecurity.wrends</groupId>
+    <artifactId>opendj-project</artifactId>
     <version>4.0.0-M4-SNAPSHOT</version>
   </parent>
   <artifactId>opendj-server</artifactId>
@@ -39,15 +39,15 @@
   </properties>
   <dependencies>
     <dependency>
-      <groupId>org.forgerock.opendj</groupId>
+      <groupId>org.wrensecurity.wrends</groupId>
       <artifactId>opendj-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.forgerock.opendj</groupId>
+      <groupId>org.wrensecurity.wrends</groupId>
       <artifactId>opendj-grizzly</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.forgerock.opendj</groupId>
+      <groupId>org.wrensecurity.wrends</groupId>
       <artifactId>opendj-config</artifactId>
     </dependency>
     <dependency>
@@ -63,7 +63,7 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.forgerock.opendj</groupId>
+      <groupId>org.wrensecurity.wrends</groupId>
       <artifactId>opendj-core</artifactId>
       <type>test-jar</type>
       <scope>test</scope>
@@ -73,7 +73,7 @@
       <artifactId>wrensec-build-tools</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.forgerock.opendj</groupId>
+      <groupId>org.wrensecurity.wrends</groupId>
       <artifactId>opendj-cli</artifactId>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -13,26 +13,27 @@
   information: "Portions Copyright [year] [name of copyright owner]".
 
   Copyright 2011-2016 ForgeRock AS.
-  Portions Copyright 2017-2021 Wren Security.
+  Portions Copyright 2017-2022 Wren Security.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.forgerock.opendj</groupId>
-        <artifactId>opendj-bom</artifactId>
-        <version>4.0.0-M4-SNAPSHOT</version>
-        <relativePath>opendj-bom/pom.xml</relativePath>
+        <groupId>org.wrensecurity</groupId>
+        <artifactId>wrensec-parent</artifactId>
+        <version>3.5.0</version>
+        <relativePath />
     </parent>
 
-    <artifactId>opendj-parent</artifactId>
+    <groupId>org.wrensecurity.wrends</groupId>
+    <artifactId>opendj-project</artifactId>
+    <version>4.0.0-M4-SNAPSHOT</version>
     <packaging>pom</packaging>
 
-    <name>Wren:DS Directory Services Project</name>
+    <name>Wren:DS - Parent</name>
     <description>
-        Wren:DS is an LDAPv3 compliant directory service, developed for the Java
-        platform, providing a high performance, highly available, secure store
-        for the identities managed by enterprises.
+        Wren:DS is an LDAPv3 compliant directory service, developed for the Java platform, providing
+        a high performance, highly available, secure store for the identities managed by enterprises.
     </description>
 
     <inceptionYear>2017</inceptionYear>
@@ -58,6 +59,36 @@
         <developerConnection>scm:git:git@github.com:WrenSecurity/WrenDS.git</developerConnection>
         <tag>HEAD</tag>
     </scm>
+
+    <repositories>
+        <repository>
+            <id>wrensecurity-releases</id>
+            <name>Wren Security Release Repository</name>
+            <url>https://wrensecurity.jfrog.io/wrensecurity/releases</url>
+
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+        </repository>
+
+        <repository>
+            <id>wrensecurity-snapshots</id>
+            <name>Wren Security Snapshot Repository</name>
+            <url>https://wrensecurity.jfrog.io/wrensecurity/snapshots</url>
+
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+        </repository>
+    </repositories>
 
     <properties>
         <product.name>Wren:DS</product.name>
@@ -87,17 +118,24 @@
         <checkstyleVersion>5.5</checkstyleVersion>
     </properties>
 
-
     <dependencyManagement>
         <dependencies>
-          <!-- Dropwizard metrics-core -->
+            <dependency>
+                <groupId>org.wrensecurity.wrends</groupId>
+                <artifactId>opendj-bom</artifactId>
+                <version>${project.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+
+            <!-- Dropwizard metrics-core -->
             <dependency>
                 <groupId>io.dropwizard.metrics</groupId>
                 <artifactId>metrics-core</artifactId>
                 <version>${metrics-core.version}</version>
             </dependency>
 
-            <!-- Commons -->
+            <!-- Commons Build Tools -->
             <dependency>
                 <groupId>org.wrensecurity</groupId>
                 <artifactId>wrensec-build-tools</artifactId>
@@ -105,9 +143,8 @@
                 <scope>test</scope>
             </dependency>
 
-            <!-- Wren:DS SDK -->
             <dependency>
-                <groupId>org.forgerock.opendj</groupId>
+                <groupId>org.wrensecurity.wrends</groupId>
                 <artifactId>opendj-core</artifactId>
                 <type>test-jar</type>
                 <version>${project.version}</version>
@@ -115,19 +152,19 @@
             </dependency>
 
             <dependency>
-                <groupId>org.forgerock.opendj</groupId>
+                <groupId>org.wrensecurity.wrends</groupId>
                 <artifactId>opendj-config</artifactId>
                 <version>${project.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>org.forgerock.opendj</groupId>
+                <groupId>org.wrensecurity.wrends</groupId>
                 <artifactId>opendj-legacy</artifactId>
                 <version>${project.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>org.forgerock.opendj</groupId>
+                <groupId>org.wrensecurity.wrends</groupId>
                 <artifactId>opendj-server</artifactId>
                 <version>${project.version}</version>
             </dependency>
@@ -225,7 +262,7 @@
                 </plugin>
 
                 <plugin>
-                    <groupId>org.forgerock.opendj</groupId>
+                    <groupId>org.wrensecurity.wrends</groupId>
                     <artifactId>opendj-doc-maven-plugin</artifactId>
                     <version>${project.version}</version>
                 </plugin>
@@ -253,30 +290,10 @@
                 </plugin>
 
                 <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-site-plugin</artifactId>
-                    <configuration>
-                        <locales>en</locales>
-                    </configuration>
-                </plugin>
-
-                <plugin>
+                    <?m2e execute onConfiguration?>
                     <groupId>org.wrensecurity.commons</groupId>
                     <artifactId>i18n-maven-plugin</artifactId>
-                    <version>${wrensec-commons.version}</version>
-                </plugin>
-
-                <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>cobertura-maven-plugin</artifactId>
-                    <version>2.7</version>
-                    <configuration>
-                        <instrumentation>
-                            <excludes>
-                                <exclude>**/*Messages.class</exclude>
-                            </excludes>
-                        </instrumentation>
-                    </configuration>
+                    <version>22.3.0</version>
                 </plugin>
 
                 <!-- This is needed to use annotations in maven plugins with maven 3.0.x -->
@@ -301,7 +318,7 @@
 
                 <plugin>
                     <?m2e ignore?>
-                    <groupId>org.forgerock.opendj</groupId>
+                    <groupId>org.wrensecurity.wrends</groupId>
                     <artifactId>opendj-copyright-maven-plugin</artifactId>
                     <version>${opendj-copyright-maven-plugin.version}</version>
                     <configuration>
@@ -337,7 +354,7 @@
 
                 <plugin>
                     <?m2e ignore?>
-                    <groupId>org.forgerock.opendj</groupId>
+                    <groupId>org.wrensecurity.wrends</groupId>
                     <artifactId>opendj-maven-plugin</artifactId>
                     <version>${project.version}</version>
                     <!-- bootstrap and bootstrap-client MANIFEST.MF files generation. -->
@@ -437,77 +454,6 @@
             <modules>
                 <module>opendj-packages</module>
             </modules>
-        </profile>
-
-        <profile>
-            <id>packages-oem</id>
-            <modules>
-                <module>opendj-packages</module>
-            </modules>
-        </profile>
-
-        <profile>
-            <id>precommit</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.forgerock.opendj</groupId>
-                        <artifactId>opendj-copyright-maven-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>check-copyright</id>
-                                <goals>
-                                    <goal>check-copyright</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-
-        <profile>
-            <id>update-copyrights</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.forgerock.opendj</groupId>
-                        <artifactId>opendj-copyright-maven-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>check-copyright</id>
-                                <phase>none</phase>
-                                <goals>
-                                    <goal>check-copyright</goal>
-                                </goals>
-                            </execution>
-                            <execution>
-                                <id>update-copyright</id>
-                                <goals>
-                                    <goal>update-copyright</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-
-        <profile>
-            <id>disable-doclint-for-java-8</id>
-            <activation>
-                <jdk>[1.8,)</jdk>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-javadoc-plugin</artifactId>
-                        <configuration>
-                            <additionalparam>-Xdoclint:none</additionalparam>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
         </profile>
     </profiles>
 


### PR DESCRIPTION
Changes:

* update project structure so that BOM is not parent
* change groupId to org.wrensecurity.wrends
* switched to updated forgerock-doc-maven-plugin (SNAPSHOT at the moment)

~We need to decide what to do with [forgerock-doc-maven-plugin](https://github.com/WrenSecurity/forgerock-commons-old/tree/master/forgerock-doc-maven-plugin) that I have now switched to OIP artifact.~