### PR TITLE
Export sun.security modules on Java 11+

### DIFF
--- a/opendj-cli/src/main/java/com/forgerock/opendj/cli/CliConstants.java
+++ b/opendj-cli/src/main/java/com/forgerock/opendj/cli/CliConstants.java
@@ -22,7 +22,7 @@ package com.forgerock.opendj.cli;
 public final class CliConstants {
 
     /** The minimum java specification supported string version. */
-    public static final float MINIMUM_JAVA_VERSION = 1.7F;
+    public static final float MINIMUM_JAVA_VERSION = 1.8F;
 
     /** Default value for LDAP connection timeout. */
     public static final int DEFAULT_LDAP_CONNECT_TIMEOUT = 30000;

--- a/opendj-server-legacy/resource/bin/_script-util.bat
+++ b/opendj-server-legacy/resource/bin/_script-util.bat
@@ -13,6 +13,7 @@ rem information: "Portions Copyright [year] [name of copyright owner]".
 rem
 rem Copyright 2008-2010 Sun Microsystems, Inc.
 rem Portions Copyright 2011-2016 ForgeRock AS.
+rem Portions Copyright 2022 Wren Security
 
 set SET_JAVA_HOME_AND_ARGS_DONE=false
 set SET_ENVIRONMENT_VARS_DONE=false
@@ -155,9 +156,9 @@ goto endJavaHomeAndArgs
 
 :noJavaFound
 echo ERROR:  Could not find a valid Java binary to be used.
-echo You must specify the path to a valid Java 7 or higher version.
+echo You must specify the path to a valid Java 8 or higher version.
 echo The procedure to follow is to set the environment variable OPENDJ_JAVA_HOME
-echo to the root of a valid Java 7 installation.
+echo to the root of a valid Java 8 installation.
 echo If you want to have specific Java settings for each command line you must
 echo edit the properties file specifying the Java binary and the Java arguments
 echo for each command line.  The Java properties file is located in:
@@ -170,6 +171,9 @@ if %SET_ENVIRONMENT_VARS_DONE% == "true" goto end
 set PATH=%SystemRoot%;%PATH%
 set SCRIPT_NAME_ARG=-Dorg.opends.server.scriptName=%SCRIPT_NAME%
 set SET_ENVIRONMENT_VARS_DONE=true
+"%OPENDJ_JAVA_BIN%" --add-exports java.base/sun.security.x509=ALL-UNNAMED --add-exports java.base/sun.security.tools.keytool=ALL-UNNAMED --version > NUL 2>&1
+set RESULT_CODE=%errorlevel%
+if %RESULT_CODE% == 0 set OPENDJ_JAVA_ARGS=%OPENDJ_JAVA_ARGS% --add-exports java.base/sun.security.x509=ALL-UNNAMED --add-exports java.base/sun.security.tools.keytool=ALL-UNNAMED
 goto scriptBegin
 
 :testJava
@@ -191,9 +195,9 @@ if NOT "%OPENDJ_JAVA_ARGS%" == "" goto noValidHomeWithArgs
 echo ERROR:  The detected Java version could not be used.  The detected
 echo Java binary is:
 echo %OPENDJ_JAVA_BIN%
-echo You must specify the path to a valid Java 7 or higher version.
+echo You must specify the path to a valid Java 8 or higher version.
 echo The procedure to follow is to set the environment variable OPENDJ_JAVA_HOME
-echo to the root of a valid Java 7 installation.
+echo to the root of a valid Java 8 installation.
 echo If you want to have specific Java settings for each command line you must
 echo edit the properties file specifying the Java binary and the Java arguments
 echo for each command line.  The Java properties file is located in:

--- a/opendj-server-legacy/resource/bin/_script-util.sh
+++ b/opendj-server-legacy/resource/bin/_script-util.sh
@@ -14,12 +14,13 @@
 #
 # Copyright 2008-2010 Sun Microsystems, Inc.
 # Portions Copyright 2010-2016 ForgeRock AS.
+# Portions Copyright 2022 Wren Security
 
 #
 # Display an error message
 #
 display_java_not_found_error() {
-  echo "Please set OPENDJ_JAVA_HOME to the root of a Java 7 (or higher) installation"
+  echo "Please set OPENDJ_JAVA_HOME to the root of a Java 8 (or higher) installation"
   echo "or edit the java.properties file to specify the Java version to be used"
 }
 
@@ -42,7 +43,7 @@ get_property() {
 #                                      is defined and 'default.java-home'/bin/java points to a regular file
 # 5 - use `which java` command to find java path
 # 6 - use JAVA_BIN if defined and points to an existing regular file
-# 7 - use JAVA_HOME if defined and JAVA_HOME/bin/java points to a regural file
+# 7 - use JAVA_HOME if defined and JAVA_HOME/bin/java points to a regular file
 # 8 - Displays an error message which says that java was not found on the running machine
 set_opendj_java_bin() {
   if test ! -z "${OPENDJ_JAVA_BIN}" -a -f "${OPENDJ_JAVA_BIN}"
@@ -123,9 +124,9 @@ print_error_message() {
   else
     echo "The detected Java binary is: ${OPENDJ_JAVA_BIN}"
   fi
-  echo "You must specify the path to a valid Java 7 or higher version."
+  echo "You must specify the path to a valid Java 8 or higher version."
   echo "The procedure to follow is to set the environment variable OPENDJ_JAVA_HOME"
-  echo "to the root of a valid Java 7 installation."
+  echo "to the root of a valid Java 8 installation."
   echo "If you want to have specific Java settings for each command line you must"
   echo "edit the properties file specifying the Java binary and/or the Java arguments"
   echo "for each command line.  The Java properties file is located in:"
@@ -183,6 +184,10 @@ set_environment_vars() {
        LD_PRELOAD LD_PRELOAD_32 LD_PRELOAD_64
   SCRIPT_NAME_ARG=-Dorg.opends.server.scriptName=${SCRIPT_NAME}
 	export SCRIPT_NAME_ARG
+  JAVA_MAJOR_VERSION=$("$OPENDJ_JAVA_BIN" -version 2>&1 | sed -E 's/.*version "([0-9]+).*/\1/; 1q')
+  if [ "$JAVA_MAJOR_VERSION" -ge 11 ]; then
+    export OPENDJ_JAVA_ARGS="$OPENDJ_JAVA_ARGS --add-exports java.base/sun.security.x509=ALL-UNNAMED --add-exports java.base/sun.security.tools.keytool=ALL-UNNAMED"
+  fi
 }
 
 # Configure the appropriate CLASSPATH for server, using Opend DJ logger.


### PR DESCRIPTION
Some `com.sun.security` packages are not exported from java.base module.