### PR TITLE
Fix build of system-specific packages 

### DIFF
--- a/opendj-doc-generated-ref/src/main/docbkx/man-pages/create-rc-script-examples.xml
+++ b/opendj-doc-generated-ref/src/main/docbkx/man-pages/create-rc-script-examples.xml
@@ -13,6 +13,7 @@
   information: "Portions Copyright [year] [name of copyright owner]".
 
   Copyright 2015-2016 ForgeRock AS.
+  Portions Copyright 2022 Wren Security.
 -->
 <refsect1 xmlns="http://docbook.org/ns/docbook"
           version="5.0" xml:lang="en"
@@ -23,13 +24,13 @@
  <title>Examples</title>
 
  <para>
-  The following example adds a script to start OpenDJ at boot time
+  The following example adds a script to start Wren:DS at boot time
   on a Debian-based system,
   and then updates the runlevel system to use the script.
  </para>
 
  <screen>
-$ <userinput>sudo create-rc-script -f /etc/init.d/opendj -u opendj-user</userinput>
-$ <userinput>sudo update-rc.d opendj</userinput>
+$ <userinput>sudo create-rc-script -f /etc/init.d/wrends -u opendj-user</userinput>
+$ <userinput>sudo update-rc.d wrends</userinput>
  </screen>
 </refsect1>

--- a/opendj-packages/opendj-deb/pom.xml
+++ b/opendj-packages/opendj-deb/pom.xml
@@ -39,7 +39,7 @@
         <deb.maintainer>info@wrensecurity.org</deb.maintainer>
         <manpage.dir>${project.build.directory}/dependency/man</manpage.dir>
         <deb.doc.homepage.url>https://wrensecurity.org/</deb.doc.homepage.url>
-        <sysv.file.location>${project.parent.basedir}/resources/sysv/opendj</sysv.file.location>
+        <sysv.file.location>${project.parent.basedir}/resources/sysv/wrends</sysv.file.location>
         <deb.product.name>${product.name}</deb.product.name>
         <deb.product.name.lowercase>${product.name.lowercase}</deb.product.name.lowercase>
     </properties>
@@ -151,6 +151,7 @@
                         <configuration>
                             <deb>${project.build.directory}/${deb.product.name.lowercase}_${project.version}-${deb.release}_all.deb</deb>
                             <controlDir>${project.build.directory}/deb/control</controlDir>
+                            <skipPOMs>false</skipPOMs>
                             <dataSet>
                                 <!-- Wren:DS service file -->
                                 <data>

--- a/opendj-packages/opendj-deb/resources/control/postinst
+++ b/opendj-packages/opendj-deb/resources/control/postinst
@@ -13,16 +13,17 @@
 # information: "Portions Copyright [year] [name of copyright owner]".
 #
 # Copyright 2013-2015 ForgeRock AS.
+# Portions Copyright 2022 Wren Security.
 
 # Post install script
 # Install is launched with an empty second arg.
 # If the package is already installed, the second arg. is not empty.
 
 # Registers the service
-update-rc.d opendj defaults
+update-rc.d wrends defaults
 
 # Symlinks to process ID
-test -h "/var/run/opendj.pid" || ln -s ${deb.prefix}/logs/server.pid /var/run/opendj.pid
+test -h "/var/run/wrends.pid" || ln -s ${deb.prefix}/logs/server.pid /var/run/wrends.pid
 
 # In this case, we are in upgrade mode.
 if [ "$1" = "configure" ] && [ ! -z "$2" ] ; then

--- a/opendj-packages/opendj-deb/resources/control/postrm
+++ b/opendj-packages/opendj-deb/resources/control/postrm
@@ -13,13 +13,14 @@
 # information: "Portions Copyright [year] [name of copyright owner]".
 #
 # Copyright 2013-2015 ForgeRock AS.
+# Portions Copyright 2022 Wren Security.
 
 set -e
 # Post rm script
 # Files are removed automatically by pm.
 if [ "$1" = "remove" ] ; then
     # Deletes the service.
-    update-rc.d -f opendj remove
+    update-rc.d -f wrends remove
     echo
     echo *OpenDJ successfully removed
 fi

--- a/opendj-packages/opendj-deb/resources/control/prerm
+++ b/opendj-packages/opendj-deb/resources/control/prerm
@@ -13,11 +13,12 @@
 # information: "Portions Copyright [year] [name of copyright owner]".
 #
 # Copyright 2013-2015 ForgeRock AS.
+# Portions Copyright 2022 Wren Security.
 
 set -e
 # Pre rm script
 # Unlink the symlink to the process ID if it exists.
-test -h "/var/run/opendj.pid" && unlink /var/run/opendj.pid
+test -h "/var/run/wrends.pid" && unlink /var/run/wrends.pid
 
 # Stops the server if the instance has been configured
 if [ "$1" = "remove" ] && ( [ -f ${deb.prefix}/config/buildinfo ] && [ "$(ls -A ${deb.prefix}/config/archived-configs)" ] ) ; then

--- a/opendj-packages/opendj-msi/resources/msi/package.wxs
+++ b/opendj-packages/opendj-msi/resources/msi/package.wxs
@@ -13,19 +13,20 @@
  ! information: "Portions Copyright [year] [name of copyright owner]".
  !
  ! Copyright 2013-2016 ForgeRock AS.
+ ! Portions Copyright 2022 Wren Security.
  ! -->
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
-  <Product Id="*" Codepage="1252" Language="1033" Manufacturer="ForgeRock"
-           Name="ForgeRock $(var.name) $(var.major).$(var.minor).$(var.point)" Version="$(var.major).$(var.minor).$(var.point)"
+  <Product Id="*" Codepage="1252" Language="1033" Manufacturer="Wren Security"
+           Name="Wren Security $(var.name) $(var.major).$(var.minor).$(var.point)" Version="$(var.major).$(var.minor).$(var.point)"
            UpgradeCode="A3E82AC0-88E6-4DEE-9D8C-5AE3B7853274">
-    <Package Id="*" Comments="This package contains ForgeRock $(var.name) $(var.major).$(var.minor).$(var.point)."
-             Description="ForgeRock products" InstallerVersion="300" Languages="1033" Manufacturer="ForgeRock"
+    <Package Id="*" Comments="This package contains Wren Security $(var.name) $(var.major).$(var.minor).$(var.point)."
+             Description="Wren Security products" InstallerVersion="300" Languages="1033" Manufacturer="Wren Security"
              Platform="x86" Compressed="yes"/>
     <Media Id="1" Cabinet="opendj.cab" DiskPrompt="Disk 1" EmbedCab="yes" CompressionLevel="high"/>
-    <Property Id="DiskPrompt" Value="ForgeRock $(var.name) $(var.major).$(var.minor).$(var.point) Installation"/>
+    <Property Id="DiskPrompt" Value="Wren Security $(var.name) $(var.major).$(var.minor).$(var.point) Installation"/>
 
     <Property Id="ALLUSERS" Value="1"/>
-    <Property Id="ARPHELPLINK" Value="http://forgerock.com"/>
+    <Property Id="ARPHELPLINK" Value="http://wrensecurity.org"/>
 
     <!-- UI customization -->
     <WixVariable Id="WixUIBannerBmp" Value="opendjbanner.bmp" />

--- a/opendj-packages/opendj-rpm/pom.xml
+++ b/opendj-packages/opendj-rpm/pom.xml
@@ -36,7 +36,7 @@
         <rpm.prefix>/opt/${product.name.lowercase}</rpm.prefix>
         <manpage.dir>${project.build.directory}/dependency/man</manpage.dir>
         <doc.homepage.url>https://wrensecurity.org/</doc.homepage.url>
-        <sysv.file.location>${project.parent.basedir}/resources/sysv/opendj</sysv.file.location>
+        <sysv.file.location>${project.parent.basedir}/resources/sysv/wrends</sysv.file.location>
         <rpm.product.name>${product.name}</rpm.product.name>
         <rpm.product.name.lowercase>${product.name.lowercase}</rpm.product.name.lowercase>
         <rpm.resources.path>${project.basedir}/resources</rpm.resources.path>

--- a/opendj-packages/opendj-rpm/resources/specs/postinstall.sh
+++ b/opendj-packages/opendj-rpm/resources/specs/postinstall.sh
@@ -13,6 +13,7 @@
 # information: "Portions Copyright [year] [name of copyright owner]".
 #
 # Copyright 2013-2015 ForgeRock AS.
+# Portions Copyright 2022 Wren Security.
 
 # ===============================
 # RPM Post Install Script (%post)
@@ -23,10 +24,10 @@
 #  an uninstallation.)
 
 # Registers the service
-/sbin/chkconfig --add opendj
+/sbin/chkconfig --add wrends
 
 # Symlinks to process ID
-test -h "/var/run/opendj.pid" || ln -s /opt/opendj/logs/server.pid /var/run/opendj.pid
+test -h "/var/run/wrends.pid" || ln -s /opt/wrends/logs/server.pid /var/run/wrends.pid
 
 if [ "$1" == "1" ] ; then
     echo "Post Install - initial install"

--- a/opendj-packages/opendj-rpm/resources/specs/preuninstall.sh
+++ b/opendj-packages/opendj-rpm/resources/specs/preuninstall.sh
@@ -13,6 +13,7 @@
 # information: "Portions Copyright [year] [name of copyright owner]".
 #
 # Copyright 2013-2015 ForgeRock AS.
+# Portions Copyright 2022 Wren Security.
 
 # =================================
 # RPM Pre Uninstall Script (%preun)
@@ -24,15 +25,15 @@
 if [ "$1" == "0" ] ; then
     echo "Pre Uninstall - uninstall"
     # Unlink the symlink to the process ID.
-    test -h "/var/run/opendj.pid" && unlink /var/run/opendj.pid
+    test -h "/var/run/wrends.pid" && unlink /var/run/wrends.pid
     # Only if the instance has been configured
     if [ -e "%{_prefix}"/config/buildinfo ] && [ "$(ls -A "%{_prefix}"/config/archived-configs)" ] ; then
 	   "%{_prefix}"/bin/./stop-ds
     fi
 
-    if [ -e /etc/init.d/opendj ] ; then
+    if [ -e /etc/init.d/wrends ] ; then
         # Deletes the service.
-        /sbin/chkconfig --del opendj
+        /sbin/chkconfig --del wrends
     fi
 else if [ "$1" == "1" ] ; then
     echo "Pre Uninstall - upgrade uninstall"

--- a/opendj-packages/resources/sysv/wrends
+++ b/opendj-packages/resources/sysv/wrends
@@ -1,6 +1,6 @@
 #! /bin/sh
 #
-# OPENDJ SERVICE SCRIPT
+# WREN:DS SERVICE SCRIPT
 #
 
 #
@@ -17,22 +17,23 @@
 # information: "Portions Copyright [year] [name of copyright owner]".
 #
 # Copyright 2013-2015 ForgeRock AS.
+# Portions Copyright 2022 Wren Security.
 
 
 # chkconfig: 2345 80 05
-# description: Starts and stops opendj LDAPv3 service.
+# description: Starts and stops wrends LDAPv3 service.
 #
 ### BEGIN INIT INFO
-# Provides:          opendj
+# Provides:          wrends
 # Required-Start:
 # Required-Stop:
 # Default-Start:     2 3 4 5
 # Default-Stop:      0 1 6
-# Short-Description: This is the opendj daemon
-# Description:       OpenDJ is an LDAPv3 compliant directory service, developed for the Java
+# Short-Description: This is the wrends daemon
+# Description:       Wren:DS is an LDAPv3 compliant directory service, developed for the Java
 #                    platform, providing a high performance, highly available and secure store
 #                    for the identities managed by enterprises. Its easy installation process,
-#                    combined with the power of the Java platform makes OpenDJ one of the
+#                    combined with the power of the Java platform makes Wren:DS one of the
 #                    simplest and fastest directory servers to deploy and manage.
 ### END INIT INFO
 
@@ -40,34 +41,34 @@
 if [ -f /etc/redhat-release ] ; then
     # Redhat
     . /etc/init.d/functions
-    LOCKFILE=/var/lock/subsys/opendj
+    LOCKFILE=/var/lock/subsys/wrends
 elif [ -f /etc/SuSE-release ] ; then
     # SuSE
     . /etc/rc.status
-    LOCKFILE=/var/run/rcopendj
+    LOCKFILE=/var/run/rcwrends
 elif [ -f /etc/lsb-release ] || lsb_release -a >/dev/null 2>&1 ; then
     # Debian
     # On Debian 8 the file /etc/lsb-release does not exist. The lsb_release command may be used instead.
     . /lib/lsb/init-functions
-    LOCKFILE=/var/lock/opendj
+    LOCKFILE=/var/lock/wrends
 elif [ -f /etc/init.d/functions.sh ] ; then
     # Other dist.
     . /etc/init.d/functions.sh
-    LOCKFILE=/tmp/unused-lockfile-opendj
+    LOCKFILE=/tmp/unused-lockfile-wrends
 fi
-# LOCKFILE is used by the service subsystem to know whether the opendj service is started and act upon it
+# LOCKFILE is used by the service subsystem to know whether the wrends service is started and act upon it
 
 
 # Sets the script vars
-INSTALL_ROOT="/opt/opendj"
+INSTALL_ROOT="/opt/wrends"
 export INSTALL_ROOT
-DAEMON=opendj
+DAEMON=wrends
 
 # Original PID file
-ORIGINPIDFILE=/opt/opendj/logs/server.pid
+ORIGINPIDFILE=/opt/wrends/logs/server.pid
 
-# Pid file is a symlink to /opt/opendj/log/server.pid
-PIDFILE=/var/run/opendj.pid
+# Pid file is a symlink to /opt/wrends/log/server.pid
+PIDFILE=/var/run/wrends.pid
 RETVAL=0
 
 # If the daemon is not there, then exit / LSB return code.


### PR DESCRIPTION
I checked the following packages: `deb`, `rpm`, `msi`.

With the proposed changes were all the mentioned packages fully buildable and working. All the instances were successfully managed through system service.