### PR TITLE
Partial fix of opendj-server-legacy unit tests

### DIFF
--- a/opendj-config/src/test/java/org/forgerock/opendj/config/ConfigurationMock.java
+++ b/opendj-config/src/test/java/org/forgerock/opendj/config/ConfigurationMock.java
@@ -24,6 +24,7 @@ import java.util.SortedSet;
 import java.util.TreeSet;
 
 import org.mockito.internal.stubbing.defaultanswers.ReturnsEmptyValues;
+import org.mockito.internal.util.Primitives;
 import org.mockito.invocation.InvocationOnMock;
 
 /**
@@ -88,6 +89,9 @@ public final class ConfigurationMock {
                 Object defaultValue = getDefaultValue(definition, getPropertyDefMethod, propertyReturnType);
                 if (defaultValue != null) {
                     return defaultValue;
+                }
+                if (Number.class.isAssignableFrom(invocation.getMethod().getReturnType())) {
+                    return null; // Prevent Mockito's default behavior of returning wrapped 0
                 }
                 return answerFromDefaultMockitoBehavior(invocation);
             } catch (Exception e) {

--- a/opendj-server-legacy/pom.xml
+++ b/opendj-server-legacy/pom.xml
@@ -37,6 +37,7 @@
         <!-- General server-wide properties -->
         <docgen.dir>${project.build.directory}/docgen</docgen.dir>
         <jars.dir>${project.build.directory}/jars</jars.dir>
+
         <!-- Product information properties -->
         <patchFixIds />
         <isDebugBuild>false</isDebugBuild>
@@ -44,8 +45,10 @@
         <docWikiUrl>https://wrensecurity.org/projects/wrends/resources.html</docWikiUrl>
         <docGuideRefUrl>http://opendj.forgerock.org/opendj-server-legacy/doc/bootstrap/admin-guide/</docGuideRefUrl>
         <docGuideAdminUrl>http://opendj.forgerock.org/opendj-server-legacy/doc/bootstrap/admin-guide/</docGuideAdminUrl>
+
         <!-- Other properties -->
         <maven.build.timestamp.format>yyyyMMdd</maven.build.timestamp.format>
+
         <!-- Additional OSGI import package for this module -->
         <opendj.osgi.import.additional>
             org.forgerock.opendj.*;provide:=true,
@@ -53,6 +56,14 @@
         </opendj.osgi.import.additional>
         <product.archive.name>${product.name.lowercase}-${project.version}</product.archive.name>
         <juel.version>2.2.7</juel.version>
+
+        <!-- maven-failsafe-plugin JVM arguments -->
+        <argLine>
+            -server -Xms1024M -Xmx2048M
+            --add-exports java.base/sun.security.x509=ALL-UNNAMED
+            --add-exports java.base/sun.security.tools.keytool=ALL-UNNAMED
+            --add-opens java.base/java.nio=ALL-UNNAMED
+        </argLine>
     </properties>
 
     <dependencies>
@@ -173,11 +184,6 @@
         </dependency>
 
         <!-- slf4j libraries -->
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-jdk14</artifactId>
-        </dependency>
-
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>jul-to-slf4j</artifactId>
@@ -1087,57 +1093,65 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-failsafe-plugin</artifactId>
+
+                        <configuration>
+                            <testSourceDirectory>src/test/java</testSourceDirectory>
+                            <forkedProcessTimeoutInSeconds>1800</forkedProcessTimeoutInSeconds>
+                            <additionalClasspathElements>
+                                <additionalClasspathElement>${jars.dir}/wrends-slf4j-adapter.jar</additionalClasspathElement>
+                                <additionalClasspathElement>${jars.dir}/wrends-je-backend.jar</additionalClasspathElement>
+                            </additionalClasspathElements>
+                            <classpathDependencyExcludes>
+                                <classpathDependencyExclude>org.slf4j:slf4j-jdk14</classpathDependencyExclude>
+                            </classpathDependencyExcludes>
+                            <excludes>
+                                <exclude>org/opends/server/snmp/**</exclude>
+                                <exclude>org/opends/quicksetup/**</exclude>
+                                <exclude>org/opends/quicksetup/**</exclude>
+                            </excludes>
+                            <includes>
+                                <include>**/Test*.java</include>
+                                <include>**/*Test.java</include>
+                                <include>**/*Tests.java</include>
+                                <include>**/*TestCase.java</include>
+                                <include>**/*TestCases.java</include>
+                            </includes>
+                            <properties>
+                                <property>
+                                    <name>usedefaultlisteners</name>
+                                    <value>false</value>
+                                </property>
+                                <property>
+                                    <name>listener</name>
+                                    <value>org.opends.server.TestListener</value>
+                                </property>
+                                <property>
+                                    <name>excludegroups</name>
+                                    <value>slow</value>
+                                </property>
+                                <property>
+                                    <name>configfailurepolicy</name>
+                                    <value>skip</value>
+                                </property>
+                            </properties>
+                            <systemPropertyVariables>
+                                <org.opends.server.BuildRoot>${basedir}</org.opends.server.BuildRoot>
+                                <org.opends.server.BuildDir>${project.build.directory}</org.opends.server.BuildDir>
+                                <org.opends.test.replicationDbImpl>LOG</org.opends.test.replicationDbImpl>
+                                <!-- <jvmarg value="-Dorg.opends.server.snmp.opendmk=${opendmk.lib.dir}" /> -->
+                                <org.opends.server.CleanupDirectories>true</org.opends.server.CleanupDirectories>
+                                <org.opends.test.suppressOutput>true</org.opends.test.suppressOutput>
+                                <org.opends.test.pauseOnFailure>false</org.opends.test.pauseOnFailure>
+                                <org.opends.test.copyClassesToTestPackage>false</org.opends.test.copyClassesToTestPackage>
+                            </systemPropertyVariables>
+                        </configuration>
+
                         <executions>
                             <execution>
                                 <goals>
                                     <goal>integration-test</goal>
                                     <goal>verify</goal>
                                 </goals>
-                                <configuration>
-                                    <testSourceDirectory>src/test/java</testSourceDirectory>
-                                    <forkedProcessTimeoutInSeconds>1800</forkedProcessTimeoutInSeconds>
-                                    <excludes>
-                                        <exclude>org/opends/server/snmp/**</exclude>
-                                        <exclude>org/opends/quicksetup/**</exclude>
-                                        <exclude>org/opends/quicksetup/**</exclude>
-                                    </excludes>
-                                    <includes>
-                                        <include>**/Test*.java</include>
-                                        <include>**/*Test.java</include>
-                                        <include>**/*Tests.java</include>
-                                        <include>**/*TestCase.java</include>
-                                        <include>**/*TestCases.java</include>
-                                    </includes>
-                                    <properties>
-                                        <property>
-                                            <name>usedefaultlisteners</name>
-                                            <value>false</value>
-                                        </property>
-                                        <property>
-                                            <name>listener</name>
-                                            <value>org.opends.server.TestListener</value>
-                                        </property>
-                                        <property>
-                                            <name>excludegroups</name>
-                                            <value>slow</value>
-                                        </property>
-                                        <property>
-                                            <name>configfailurepolicy</name>
-                                            <value>skip</value>
-                                        </property>
-                                    </properties>
-                                    <systemPropertyVariables>
-                                        <org.opends.server.BuildRoot>${basedir}</org.opends.server.BuildRoot>
-                                        <org.opends.server.BuildDir>${project.build.directory}</org.opends.server.BuildDir>
-                                        <org.opends.test.replicationDbImpl>LOG</org.opends.test.replicationDbImpl>
-                                        <!-- <jvmarg value="-Dorg.opends.server.snmp.opendmk=${opendmk.lib.dir}" /> -->
-                                        <org.opends.server.CleanupDirectories>true</org.opends.server.CleanupDirectories>
-                                        <org.opends.test.suppressOutput>true</org.opends.test.suppressOutput>
-                                        <org.opends.test.pauseOnFailure>false</org.opends.test.pauseOnFailure>
-                                        <org.opends.test.copyClassesToTestPackage>false</org.opends.test.copyClassesToTestPackage>
-                                    </systemPropertyVariables>
-                                    <argLine>-server -Xms1024M -Xmx2048M -XX:MaxPermSize=256m</argLine>
-                                </configuration>
                             </execution>
                         </executions>
                     </plugin>

--- a/opendj-server-legacy/src/main/java/org/opends/server/types/Entry.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/types/Entry.java
@@ -30,7 +30,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -172,7 +171,7 @@ public class Entry
     {
       return map;
     }
-    return new HashMap<>();
+    return new LinkedHashMap<>();
   }
 
 
@@ -2350,14 +2349,14 @@ public class Entry
    */
   public Entry duplicate(boolean processVirtual)
   {
-    Map<ObjectClass, String> objectClassesCopy = new HashMap<>(objectClasses);
+    Map<ObjectClass, String> objectClassesCopy = new LinkedHashMap<>(objectClasses);
 
-    Map<AttributeType, List<Attribute>> userAttrsCopy = new HashMap<>(userAttributes.size());
+    Map<AttributeType, List<Attribute>> userAttrsCopy = new LinkedHashMap<>(userAttributes.size());
     deepCopy(userAttributes, userAttrsCopy, false, false, false,
         true, false);
 
     Map<AttributeType, List<Attribute>> operationalAttrsCopy =
-         new HashMap<>(operationalAttributes.size());
+         new LinkedHashMap<>(operationalAttributes.size());
     deepCopy(operationalAttributes, operationalAttrsCopy, false,
         false, false, true, false);
 

--- a/opendj-server-legacy/src/main/java/org/opends/server/util/LDIFReader.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/util/LDIFReader.java
@@ -21,6 +21,7 @@ import static org.opends.messages.UtilityMessages.*;
 import static org.opends.server.util.CollectionUtils.*;
 import static org.opends.server.util.StaticUtils.*;
 
+import com.google.common.collect.Maps;
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.Closeable;
@@ -28,7 +29,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -226,9 +227,9 @@ public class LDIFReader implements Closeable
 
   private Entry createEntry(DN entryDN, List<StringBuilder> lines, boolean checkSchema) throws LDIFException
   {
-    Map<ObjectClass, String> objectClasses = new HashMap<>();
-    Map<AttributeType, List<AttributeBuilder>> userAttrBuilders = new HashMap<>();
-    Map<AttributeType, List<AttributeBuilder>> operationalAttrBuilders = new HashMap<>();
+    Map<ObjectClass, String> objectClasses = new LinkedHashMap<>();
+    Map<AttributeType, List<AttributeBuilder>> userAttrBuilders = new LinkedHashMap<>();
+    Map<AttributeType, List<AttributeBuilder>> operationalAttrBuilders = new LinkedHashMap<>();
     for (StringBuilder line : lines)
     {
       readAttribute(lines, line, entryDN, objectClasses, userAttrBuilders, operationalAttrBuilders, checkSchema);
@@ -311,7 +312,7 @@ public class LDIFReader implements Closeable
    */
   protected Map<AttributeType, List<Attribute>> toAttributesMap(Map<AttributeType, List<AttributeBuilder>> attrBuilders)
   {
-    Map<AttributeType, List<Attribute>> attributes = new HashMap<>(attrBuilders.size());
+    Map<AttributeType, List<Attribute>> attributes = new LinkedHashMap<>(attrBuilders.size());
     for (Map.Entry<AttributeType, List<AttributeBuilder>> attrTypeEntry : attrBuilders.entrySet())
     {
       AttributeType attrType = attrTypeEntry.getKey();
@@ -1285,8 +1286,8 @@ public class LDIFReader implements Closeable
   private ChangeRecordEntry parseAddChangeRecordEntry(DN entryDN,
       List<StringBuilder> lines) throws LDIFException
   {
-    Map<ObjectClass, String> objectClasses = new HashMap<>();
-    Map<AttributeType, List<AttributeBuilder>> attrBuilders = new HashMap<>();
+    Map<ObjectClass, String> objectClasses = new LinkedHashMap<>();
+    Map<AttributeType, List<AttributeBuilder>> attrBuilders = new LinkedHashMap<>();
     for(StringBuilder line : lines)
     {
       readAttribute(lines, line, entryDN, objectClasses,

--- a/opendj-server-legacy/src/test/java/org/opends/server/TestCaseUtils.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/TestCaseUtils.java
@@ -402,8 +402,8 @@ public final class TestCaseUtils {
                                           "org", "forgerock", "opendj", "ldif").toAbsolutePath().toFile();
     File serverClassesDir = new File(paths.buildDir, "classes");
     File unitClassesDir = new File(paths.unitRoot, "classes");
-    File libDir = new File(paths.buildDir.getPath() + "/package/opendj/lib");
-    File upgradeDir = new File(paths.buildDir.getPath() + "/package/opendj/template/config/upgrade");
+    File libDir = new File(paths.buildDir.getPath() + "/package/wrends/lib");
+    File upgradeDir = new File(paths.buildDir.getPath() + "/package/wrends/template/config/upgrade");
     System.out.println("libDir=" + libDir);
     File resourceDir = new File(paths.buildRoot, "resource");
     File testResourceDir = new File(paths.testSrcRoot, "resource");

--- a/opendj-server-legacy/src/test/java/org/opends/server/TestCaseUtils.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/TestCaseUtils.java
@@ -14,6 +14,7 @@
  * Copyright 2006-2010 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
  * Portions Copyright 2013 Manuel Gaupp
+ * Portions Copyright 2023 Wren Security
  */
 package org.opends.server;
 
@@ -1924,25 +1925,20 @@ public final class TestCaseUtils {
     return dump.toString();
   }
 
-  /** FIXME Replace with {@link Assert#assertNotEquals(Object, Object)} once we upgrade to testng >= 6.1. */
-  public static void assertNotEquals(Object actual1, Object actual2)
+  /**
+   * {@link Object#equals} based assertion to workaround sneaky TestNG overloaded method.
+   */
+  public static void assertObjectEquals(Object actual, Object expected)
   {
-    assertNotEquals(actual1, actual2, null);
+      Assert.assertEquals(actual, expected);
   }
 
-  /** FIXME Replace with {@link Assert#assertNotEquals(Object, Object, String)} once we upgrade to testng >= 6.1. */
-  public static void assertNotEquals(Object actual1, Object actual2, String message)
+  /**
+   * {@link Object#equals} based assertion to workaround sneaky TestNG overloaded method.
+   */
+  public static void assertObjectEquals(Object actual, Object expected, String message)
   {
-    try
-    {
-      Assert.assertEquals(actual1, actual2);
-      Assert.fail(message);
-    }
-    catch (AssertionError e)
-    {
-      // this is good: they are not equals
-      return;
-    }
+      Assert.assertEquals(actual, expected, message);
   }
 
   public static int runLdapSearchTrustCertificateForSession(final String[] args)
@@ -1969,4 +1965,5 @@ public final class TestCaseUtils {
       System.setIn(stdin);
     }
   }
+
 }

--- a/opendj-server-legacy/src/test/java/org/opends/server/api/PasswordValidatorTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/api/PasswordValidatorTestCase.java
@@ -20,11 +20,11 @@ import static org.forgerock.opendj.ldap.ModificationType.ADD;
 import static org.forgerock.opendj.ldap.ModificationType.DELETE;
 import static org.forgerock.opendj.ldap.ModificationType.REPLACE;
 import static org.forgerock.opendj.ldap.requests.Requests.newModifyRequest;
-import static org.opends.server.TestCaseUtils.assertNotEquals;
 import static org.opends.server.TestCaseUtils.getServerLdapPort;
 import static org.opends.server.TestCaseUtils.restartServer;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 

--- a/opendj-server-legacy/src/test/java/org/opends/server/api/plugin/DirectoryServerPluginTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/api/plugin/DirectoryServerPluginTestCase.java
@@ -811,7 +811,7 @@ public class DirectoryServerPluginTestCase
     nullPlugin.initializeInternal(DirectoryServer.getInstance().getServerContext(),
         configuration.dn(), pluginTypes,
         configuration.isInvokeForInternalOperations());
-    assertEquals(nullPlugin.getPluginEntryDN(), pluginEntryDN);
+    TestCaseUtils.assertObjectEquals(nullPlugin.getPluginEntryDN(), pluginEntryDN);
   }
 
 

--- a/opendj-server-legacy/src/test/java/org/opends/server/authorization/dseecompat/AciTests.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/authorization/dseecompat/AciTests.java
@@ -17,13 +17,13 @@
  */
 package org.opends.server.authorization.dseecompat;
 
-import static org.opends.server.TestCaseUtils.assertNotEquals;
 import static org.opends.server.config.ConfigConstants.ATTR_AUTHZ_GLOBAL_ACI;
 import static org.opends.server.util.CollectionUtils.newArrayList;
 import static org.opends.server.util.CollectionUtils.newHashSet;
 import static org.opends.server.util.ServerConstants.EOL;
 import static org.opends.server.util.ServerConstants.OID_PROXIED_AUTH_V2;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;

--- a/opendj-server-legacy/src/test/java/org/opends/server/authorization/dseecompat/GetEffectiveRightsTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/authorization/dseecompat/GetEffectiveRightsTestCase.java
@@ -16,10 +16,10 @@
  */
 package org.opends.server.authorization.dseecompat;
 
-import static org.opends.server.TestCaseUtils.assertNotEquals;
 import static org.opends.server.config.ConfigConstants.ATTR_AUTHZ_GLOBAL_ACI;
 import static org.opends.server.util.ServerConstants.OID_GET_EFFECTIVE_RIGHTS;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
 
 import java.util.Map;
 

--- a/opendj-server-legacy/src/test/java/org/opends/server/authorization/dseecompat/NestedGroupDNTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/authorization/dseecompat/NestedGroupDNTestCase.java
@@ -16,9 +16,9 @@
  */
 package org.opends.server.authorization.dseecompat;
 
-import static org.opends.server.TestCaseUtils.assertNotEquals;
 import static org.opends.server.config.ConfigConstants.ATTR_AUTHZ_GLOBAL_ACI;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
 
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;

--- a/opendj-server-legacy/src/test/java/org/opends/server/authorization/dseecompat/TargetAttrTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/authorization/dseecompat/TargetAttrTestCase.java
@@ -16,10 +16,10 @@
  */
 package org.opends.server.authorization.dseecompat;
 
-import static org.opends.server.TestCaseUtils.assertNotEquals;
 import static org.opends.server.config.ConfigConstants.ATTR_AUTHZ_GLOBAL_ACI;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertTrue;
 
 import java.util.Map;

--- a/opendj-server-legacy/src/test/java/org/opends/server/backends/GenericLocalBackendTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/backends/GenericLocalBackendTestCase.java
@@ -16,8 +16,8 @@
  */
 package org.opends.server.backends;
 
-import static org.opends.server.TestCaseUtils.assertNotEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 

--- a/opendj-server-legacy/src/test/java/org/opends/server/backends/LDIFBackendTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/backends/LDIFBackendTestCase.java
@@ -238,7 +238,7 @@ public class LDIFBackendTestCase
 
     AddOperation addOperation = getRootConnection().processAdd(e);
     assertEquals(addOperation.getResultCode(), ResultCode.NO_SUCH_OBJECT);
-    assertEquals(addOperation.getMatchedDN(), DN.valueOf("o=ldif"));
+    TestCaseUtils.assertObjectEquals(addOperation.getMatchedDN(), DN.valueOf("o=ldif"));
   }
 
 
@@ -548,7 +548,7 @@ public class LDIFBackendTestCase
     SearchRequest request = newSearchRequest(dn, SearchScope.BASE_OBJECT);
     InternalSearchOperation searchOperation = getRootConnection().processSearch(request);
     assertEquals(searchOperation.getResultCode(), ResultCode.NO_SUCH_OBJECT);
-    assertEquals(searchOperation.getMatchedDN(), DN.valueOf("o=ldif"));
+    TestCaseUtils.assertObjectEquals(searchOperation.getMatchedDN(), DN.valueOf("o=ldif"));
   }
 
 

--- a/opendj-server-legacy/src/test/java/org/opends/server/backends/SchemaBackendTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/backends/SchemaBackendTestCase.java
@@ -32,7 +32,6 @@ import static org.forgerock.opendj.ldap.schema.CoreSchema.getModifyTimestampAttr
 import static org.forgerock.opendj.ldap.schema.CoreSchema.getObjectClassesAttributeType;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
-import static org.opends.server.TestCaseUtils.assertNotEquals;
 import static org.opends.server.TestCaseUtils.getServerContext;
 import static org.opends.server.protocols.internal.InternalClientConnection.getRootConnection;
 import static org.opends.server.protocols.internal.InternalClientConnection.nextMessageID;
@@ -43,6 +42,7 @@ import static org.opends.server.types.NullOutputStream.nullPrintStream;
 import static org.opends.server.util.StaticUtils.createEntry;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
@@ -163,7 +163,7 @@ public class SchemaBackendTestCase extends BackendTestCase
     DN    schemaDN    = DN.valueOf("cn=schema");
     Entry schemaEntry = schemaBackend.getEntry(schemaDN);
     assertNotNull(schemaEntry);
-    assertEquals(schemaEntry.getName(), schemaDN);
+    TestCaseUtils.assertObjectEquals(schemaEntry.getName(), schemaDN);
 
     assertTrue(schemaEntry.hasAttribute(getAttributeTypesAttributeType()));
     assertTrue(schemaEntry.hasAttribute(getObjectClassesAttributeType()));
@@ -202,7 +202,7 @@ public class SchemaBackendTestCase extends BackendTestCase
     DN    schemaDN    = DN.valueOf("cn=schema");
     Entry schemaEntry = schemaBackend.getSchemaEntry(schemaDN);
     assertNotNull(schemaEntry);
-    assertEquals(schemaEntry.getName(), schemaDN);
+    TestCaseUtils.assertObjectEquals(schemaEntry.getName(), schemaDN);
 
     assertTrue(schemaEntry.hasAttribute(getAttributeTypesAttributeType()));
     assertTrue(schemaEntry.hasAttribute(getObjectClassesAttributeType()));
@@ -212,7 +212,7 @@ public class SchemaBackendTestCase extends BackendTestCase
     schemaDN    = DN.valueOf("cn=subschema");
     schemaEntry = schemaBackend.getSchemaEntry(schemaDN);
     assertNotNull(schemaEntry);
-    assertEquals(schemaEntry.getName(), schemaDN);
+    TestCaseUtils.assertObjectEquals(schemaEntry.getName(), schemaDN);
 
     assertTrue(schemaEntry.hasAttribute(getAttributeTypesAttributeType()));
     assertTrue(schemaEntry.hasAttribute(getObjectClassesAttributeType()));
@@ -4849,7 +4849,7 @@ public class SchemaBackendTestCase extends BackendTestCase
   {
     DN configEntryDN =
             DN.valueOf("ds-cfg-backend-id=schema,cn=Backends,cn=config");
-    assertEquals(schemaBackend.getComponentEntryDN(), configEntryDN);
+    TestCaseUtils.assertObjectEquals(schemaBackend.getComponentEntryDN(), configEntryDN);
   }
 
   /** Tests the {@code getClassName} method. */

--- a/opendj-server-legacy/src/test/java/org/opends/server/backends/pluggable/PluggableBackendImplTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/backends/pluggable/PluggableBackendImplTestCase.java
@@ -733,12 +733,12 @@ public abstract class PluggableBackendImplTestCase<C extends PluggableBackendCfg
     renameEntry.setDN(newDN);
     backend.renameEntry(prevDN, renameEntry, op);
     Entry dbEntry = backend.getEntry(newDN);
-    assertEquals(dbEntry.getName(), newDN, "Renamed entry is missing.");
+    TestCaseUtils.assertObjectEquals(dbEntry.getName(), newDN, "Renamed entry is missing.");
 
     renameEntry.setDN(prevDN);
     backend.renameEntry(newDN, renameEntry, op);
     dbEntry = backend.getEntry(prevDN);
-    assertEquals(dbEntry.getName(), prevDN, "Original entry has not been renamed");
+    TestCaseUtils.assertObjectEquals(dbEntry.getName(), prevDN, "Original entry has not been renamed");
   }
 
   @Test(description = "OPENDJ-2404")
@@ -797,7 +797,7 @@ public abstract class PluggableBackendImplTestCase<C extends PluggableBackendCfg
     List<SearchResultEntry> result = runSearch(request, useInternalConnection);
 
     assertEquals(result.size(), 1, "Base Search should return only one Entry");
-    assertEquals(result.get(0).getName(), testBaseDN, "Base Search on the suffix should return the suffix itself");
+    TestCaseUtils.assertObjectEquals(result.get(0).getName(), testBaseDN, "Base Search on the suffix should return the suffix itself");
   }
 
   @Test
@@ -814,8 +814,7 @@ public abstract class PluggableBackendImplTestCase<C extends PluggableBackendCfg
 
     assertEquals(result.size(), 1, "One Level search should return a single child entry");
     SearchResultEntry resEntry = result.get(0);
-    assertEquals(topEntries.get(1).getName(), resEntry.getName(),
-        "One Level search should return the expected child");
+    TestCaseUtils.assertObjectEquals(topEntries.get(1).getName(), resEntry.getName(), "One Level search should return the expected child");
   }
 
   @Test
@@ -914,7 +913,7 @@ public abstract class PluggableBackendImplTestCase<C extends PluggableBackendCfg
         + " child entry");
     if (expectedEntryCount > 0)
     {
-      assertEquals(searchDN, result.get(0).getName(), "User entry search should return the expected entry");
+      TestCaseUtils.assertObjectEquals(searchDN, result.get(0).getName(), "User entry search should return the expected entry");
     }
   }
 

--- a/opendj-server-legacy/src/test/java/org/opends/server/backends/pluggable/PluggableBackendImplTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/backends/pluggable/PluggableBackendImplTestCase.java
@@ -717,7 +717,7 @@ public abstract class PluggableBackendImplTestCase<C extends PluggableBackendCfg
         returnedEntries.add(invocation.getArgument(0));
         return null;
       }
-    }).when(searchOp).returnEntry(any(Entry.class), any(List.class));
+    }).when(searchOp).returnEntry(any(Entry.class), any());
     return searchOp;
   }
 

--- a/opendj-server-legacy/src/test/java/org/opends/server/backends/pluggable/TestDnKeyFormat.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/backends/pluggable/TestDnKeyFormat.java
@@ -338,7 +338,7 @@ public class TestDnKeyFormat extends DirectoryServerTestCase {
 
         // check DN and number of attributes
         assertThat(entryBefore.getAllAttributes()).hasSameSizeAs(entryAfter.getAllAttributes());
-        assertEquals(entryBefore.getName(), entryAfter.getName());
+        TestCaseUtils.assertObjectEquals(entryBefore.getName(), entryAfter.getName());
 
         // check the object classes were not changed
         for (String ocBefore : entryBefore.getObjectClasses().values()) {
@@ -359,7 +359,7 @@ public class TestDnKeyFormat extends DirectoryServerTestCase {
             for (Attribute attrAfter : listAfter) {
               if (attrAfter.getAttributeDescription().equals(attrBefore.getAttributeDescription())) {
                 // Found the corresponding attribute
-                assertEquals(attrBefore, attrAfter);
+                TestCaseUtils.assertObjectEquals(attrBefore, attrAfter);
                 found = true;
               }
             }

--- a/opendj-server-legacy/src/test/java/org/opends/server/backends/task/TaskBackendTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/backends/task/TaskBackendTestCase.java
@@ -16,11 +16,11 @@
  */
 package org.opends.server.backends.task;
 
-import static org.opends.server.TestCaseUtils.assertNotEquals;
 import static org.opends.server.util.ServerConstants.DATE_FORMAT_GMT_TIME;
 import static org.opends.server.util.ServerConstants.TIME_ZONE_UTC;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertTrue;
 
 import java.text.SimpleDateFormat;

--- a/opendj-server-legacy/src/test/java/org/opends/server/controls/PasswordPolicyControlTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/controls/PasswordPolicyControlTestCase.java
@@ -27,7 +27,6 @@ import static org.forgerock.opendj.ldap.requests.Requests.newModifyDNRequest;
 import static org.forgerock.opendj.ldap.requests.Requests.newModifyRequest;
 import static org.forgerock.opendj.ldap.requests.Requests.newSearchRequest;
 import static org.forgerock.opendj.ldap.requests.Requests.newSimpleBindRequest;
-import static org.opends.server.TestCaseUtils.assertNotEquals;
 import static org.opends.server.TestCaseUtils.getServerLdapPort;
 import static org.opends.server.controls.PasswordPolicyErrorType.ACCOUNT_LOCKED;
 import static org.opends.server.controls.PasswordPolicyErrorType.CHANGE_AFTER_RESET;
@@ -38,6 +37,7 @@ import static org.opends.server.controls.PasswordPolicyErrorType.PASSWORD_MOD_NO
 import static org.opends.server.controls.PasswordPolicyErrorType.PASSWORD_TOO_YOUNG;
 import static org.opends.server.util.ServerConstants.OID_PASSWORD_POLICY_CONTROL;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertTrue;
 
 import java.util.List;

--- a/opendj-server-legacy/src/test/java/org/opends/server/controls/PersistentSearchControlTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/controls/PersistentSearchControlTest.java
@@ -18,7 +18,6 @@ package org.opends.server.controls;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.forgerock.opendj.ldap.requests.Requests.newModifyRequest;
-import static org.opends.server.TestCaseUtils.assertNotEquals;
 import static org.opends.server.controls.PersistentSearchChangeType.ADD;
 import static org.opends.server.controls.PersistentSearchChangeType.DELETE;
 import static org.opends.server.controls.PersistentSearchChangeType.MODIFY;
@@ -29,6 +28,7 @@ import static org.opends.server.types.NullOutputStream.nullPrintStream;
 import static org.opends.server.util.ServerConstants.OID_ENTRY_CHANGE_NOTIFICATION;
 import static org.opends.server.util.ServerConstants.OID_PERSISTENT_SEARCH;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
@@ -420,7 +420,7 @@ public class PersistentSearchControlTest extends ControlsTestCase
       assertEquals(OID_ENTRY_CHANGE_NOTIFICATION, ecnc.getOID());
       assertEquals(changeNumber, ecnc.getChangeNumber());
       assertEquals(type, ecnc.getChangeType());
-      assertEquals(dn, ecnc.getPreviousDN());
+      TestCaseUtils.assertObjectEquals(dn, ecnc.getPreviousDN());
       assertEquals(false, ecnc.isCritical()) ;
       checkEntryChangeNotificationControlToString(ecnc);
 
@@ -435,7 +435,7 @@ public class PersistentSearchControlTest extends ControlsTestCase
         assertEquals(ecnc.getOID(),newEcnc.getOID());
         assertEquals(ecnc.getChangeNumber(),newEcnc.getChangeNumber());
         assertEquals(ecnc.getChangeType(),newEcnc.getChangeType());
-        assertEquals(ecnc.getPreviousDN(),newEcnc.getPreviousDN());
+        TestCaseUtils.assertObjectEquals(ecnc.getPreviousDN(), newEcnc.getPreviousDN());
         assertEquals(ecnc.isCritical(),newEcnc.isCritical()) ;
       }
       catch (DirectoryException e)
@@ -457,7 +457,7 @@ public class PersistentSearchControlTest extends ControlsTestCase
       assertEquals(OID_ENTRY_CHANGE_NOTIFICATION, ecnc.getOID());
       assertEquals(changeNumber, ecnc.getChangeNumber());
       assertEquals(type, ecnc.getChangeType());
-      assertEquals(dn, ecnc.getPreviousDN());
+      TestCaseUtils.assertObjectEquals(dn, ecnc.getPreviousDN());
       assertEquals(isCritical, ecnc.isCritical()) ;
       checkEntryChangeNotificationControlToString(ecnc);
 
@@ -472,7 +472,7 @@ public class PersistentSearchControlTest extends ControlsTestCase
         assertEquals(ecnc.getOID(),newEcnc.getOID());
         assertEquals(ecnc.getChangeNumber(),newEcnc.getChangeNumber());
         assertEquals(ecnc.getChangeType(),newEcnc.getChangeType());
-        assertEquals(ecnc.getPreviousDN(),newEcnc.getPreviousDN());
+        TestCaseUtils.assertObjectEquals(ecnc.getPreviousDN(), newEcnc.getPreviousDN());
         assertEquals(ecnc.isCritical(),newEcnc.isCritical()) ;
       }
       catch (DirectoryException e)

--- a/opendj-server-legacy/src/test/java/org/opends/server/controls/ProxiedAuthV1ControlTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/controls/ProxiedAuthV1ControlTestCase.java
@@ -90,8 +90,7 @@ public class ProxiedAuthV1ControlTestCase
          new ProxiedAuthV1Control(ByteString.valueOfUtf8("uid=test,o=test"));
     assertEquals(proxyControl.getOID(), OID_PROXIED_AUTH_V1);
     assertTrue(proxyControl.isCritical());
-    assertEquals(proxyControl.getAuthorizationDN(),
-                 DN.valueOf("uid=test,o=test"));
+    TestCaseUtils.assertObjectEquals(proxyControl.getAuthorizationDN(), DN.valueOf("uid=test,o=test"));
 
 
     // Try an invalid DN, which will be initally accepted but will fail when
@@ -142,8 +141,7 @@ public class ProxiedAuthV1ControlTestCase
          new ProxiedAuthV1Control(DN.valueOf("uid=test,o=test"));
     assertEquals(proxyControl.getOID(), OID_PROXIED_AUTH_V1);
     assertTrue(proxyControl.isCritical());
-    assertEquals(proxyControl.getAuthorizationDN(),
-                 DN.valueOf("uid=test,o=test"));
+    TestCaseUtils.assertObjectEquals(proxyControl.getAuthorizationDN(), DN.valueOf("uid=test,o=test"));
   }
 
 
@@ -321,8 +319,7 @@ public class ProxiedAuthV1ControlTestCase
         new LDAPControl(OID_PROXIED_AUTH_V1, true, bsb.toByteString());
 
     ProxiedAuthV1Control proxyControl = ProxiedAuthV1Control.DECODER.decode(c.isCritical(), c.getValue());
-    assertEquals(proxyControl.getAuthorizationDN(),
-                 DN.valueOf("uid=test,o=test"));
+    TestCaseUtils.assertObjectEquals(proxyControl.getAuthorizationDN(), DN.valueOf("uid=test,o=test"));
   }
 
 
@@ -362,14 +359,13 @@ public class ProxiedAuthV1ControlTestCase
     ProxiedAuthV1Control proxyControl =
          new ProxiedAuthV1Control(DN.rootDN());
     assertEquals(proxyControl.getRawAuthorizationDN(), ByteString.valueOfUtf8(""));
-    assertEquals(proxyControl.getAuthorizationDN(), DN.rootDN());
+    TestCaseUtils.assertObjectEquals(proxyControl.getAuthorizationDN(), DN.rootDN());
 
     proxyControl =
          new ProxiedAuthV1Control(DN.valueOf("uid=test,o=test"));
     assertEquals(proxyControl.getRawAuthorizationDN(),
                  ByteString.valueOfUtf8("uid=test,o=test"));
-    assertEquals(proxyControl.getAuthorizationDN(),
-                 DN.valueOf("uid=test,o=test"));
+    TestCaseUtils.assertObjectEquals(proxyControl.getAuthorizationDN(), DN.valueOf("uid=test,o=test"));
   }
 
 
@@ -417,8 +413,7 @@ public class ProxiedAuthV1ControlTestCase
     ProxiedAuthV1Control proxyControl =
          new ProxiedAuthV1Control(DN.valueOf("uid=test,o=test"));
 
-    assertEquals(proxyControl.getAuthorizationEntry().getName(),
-                 DN.valueOf("uid=test,o=test"));
+    TestCaseUtils.assertObjectEquals(proxyControl.getAuthorizationEntry().getName(), DN.valueOf("uid=test,o=test"));
   }
 
 

--- a/opendj-server-legacy/src/test/java/org/opends/server/controls/ProxiedAuthV2ControlTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/controls/ProxiedAuthV2ControlTestCase.java
@@ -307,8 +307,7 @@ public class ProxiedAuthV2ControlTestCase
 
     ProxiedAuthV2Control proxyControl =
          new ProxiedAuthV2Control(ByteString.valueOfUtf8("dn:uid=test,o=test"));
-    assertEquals(proxyControl.getAuthorizationEntry().getName(),
-                 DN.valueOf("uid=test,o=test"));
+    TestCaseUtils.assertObjectEquals(proxyControl.getAuthorizationEntry().getName(), DN.valueOf("uid=test,o=test"));
   }
 
 
@@ -404,8 +403,7 @@ public class ProxiedAuthV2ControlTestCase
 
     ProxiedAuthV2Control proxyControl =
          new ProxiedAuthV2Control(ByteString.valueOfUtf8("u:test"));
-    assertEquals(proxyControl.getAuthorizationEntry().getName(),
-                 DN.valueOf("uid=test,o=test"));
+    TestCaseUtils.assertObjectEquals(proxyControl.getAuthorizationEntry().getName(), DN.valueOf("uid=test,o=test"));
   }
 
 

--- a/opendj-server-legacy/src/test/java/org/opends/server/controls/ServerSideSortControlTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/controls/ServerSideSortControlTestCase.java
@@ -16,10 +16,10 @@
  */
 package org.opends.server.controls;
 
-import static org.opends.server.TestCaseUtils.assertNotEquals;
 import static org.opends.server.protocols.internal.InternalClientConnection.getRootConnection;
 import static org.opends.server.protocols.internal.Requests.newSearchRequest;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 

--- a/opendj-server-legacy/src/test/java/org/opends/server/core/AddOperationTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/core/AddOperationTestCase.java
@@ -21,7 +21,6 @@ import static org.forgerock.opendj.ldap.requests.Requests.newAddRequest;
 import static org.forgerock.opendj.ldap.schema.CoreSchema.getDescriptionAttributeType;
 import static org.forgerock.opendj.ldap.schema.CoreSchema.getExtensibleObjectObjectClass;
 import static org.forgerock.opendj.ldap.schema.CoreSchema.getObjectClassAttributeType;
-import static org.opends.server.TestCaseUtils.assertNotEquals;
 import static org.opends.server.TestCaseUtils.getServer;
 import static org.opends.server.protocols.internal.InternalClientConnection.getRootConnection;
 import static org.opends.server.protocols.internal.InternalClientConnection.nextMessageID;
@@ -32,6 +31,7 @@ import static org.opends.server.types.NullOutputStream.nullPrintStream;
 import static org.opends.server.util.CollectionUtils.newArrayList;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 

--- a/opendj-server-legacy/src/test/java/org/opends/server/core/BackendConfigManagerTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/core/BackendConfigManagerTestCase.java
@@ -20,7 +20,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.forgerock.opendj.ldap.ModificationType.REPLACE;
 import static org.forgerock.opendj.ldap.requests.Requests.newModifyRequest;
 import static org.mockito.Mockito.mock;
-import static org.opends.server.TestCaseUtils.assertNotEquals;
 import static org.opends.server.TestCaseUtils.getServerContext;
 import static org.opends.server.core.BackendConfigManager.NamingContextFilter.LOCAL;
 import static org.opends.server.core.BackendConfigManager.NamingContextFilter.PRIVATE;
@@ -30,6 +29,7 @@ import static org.opends.server.protocols.internal.InternalClientConnection.getR
 import static org.opends.server.protocols.internal.Requests.newSearchRequest;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;

--- a/opendj-server-legacy/src/test/java/org/opends/server/core/DeleteOperationTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/core/DeleteOperationTestCase.java
@@ -16,7 +16,6 @@
  */
 package org.opends.server.core;
 
-import static org.opends.server.TestCaseUtils.assertNotEquals;
 import static org.opends.server.core.AddOperationTestCase.setWritabilityMode;
 import static org.opends.server.protocols.internal.InternalClientConnection.getRootConnection;
 import static org.opends.server.protocols.internal.InternalClientConnection.nextMessageID;
@@ -26,6 +25,7 @@ import static org.opends.server.protocols.ldap.LDAPConstants.OP_TYPE_EXTENDED_RE
 import static org.opends.server.types.NullOutputStream.nullPrintStream;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;

--- a/opendj-server-legacy/src/test/java/org/opends/server/core/GroupManagerTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/core/GroupManagerTestCase.java
@@ -528,7 +528,7 @@ public class GroupManagerTestCase
 
     Group groupInstance = groupManager.getGroupInstance(groupDN);
     assertNotNull(groupInstance);
-    assertEquals(groupInstance.getGroupDN(), groupDN);
+    TestCaseUtils.assertObjectEquals(groupInstance.getGroupDN(), groupDN);
     assertTrue(groupInstance.isMember(user1DN));
     assertTrue(groupInstance.isMember(user2DN));
     assertFalse(groupInstance.isMember(user3DN));
@@ -657,7 +657,7 @@ public class GroupManagerTestCase
 
     Group groupInstance = groupManager.getGroupInstance(groupDN);
     assertNotNull(groupInstance);
-    assertEquals(groupInstance.getGroupDN(), groupDN);
+    TestCaseUtils.assertObjectEquals(groupInstance.getGroupDN(), groupDN);
     assertTrue(groupInstance.isMember(user1DN));
     assertTrue(groupInstance.isMember(user2DN));
     assertFalse(groupInstance.isMember(user3DN));
@@ -674,7 +674,7 @@ public class GroupManagerTestCase
                                           SearchScope.WHOLE_SUBTREE, filter);
     assertTrue(memberList.hasMoreMembers());
     DN memberDN = memberList.nextMemberDN();
-    assertEquals(memberDN, user1DN);
+    TestCaseUtils.assertObjectEquals(memberDN, user1DN);
     assertFalse(memberList.hasMoreMembers());
 
     filter = SearchFilter.createFilterFromString("(uid=user.3)");
@@ -692,7 +692,7 @@ public class GroupManagerTestCase
 
     groupInstance = groupManager.getGroupInstance(groupDN);
     assertNotNull(groupInstance);
-    assertEquals(groupInstance.getGroupDN(), groupDN);
+    TestCaseUtils.assertObjectEquals(groupInstance.getGroupDN(), groupDN);
     assertTrue(groupInstance.isMember(user1DN));
     assertFalse(groupInstance.isMember(user2DN));
     assertTrue(groupInstance.isMember(user3DN));
@@ -745,7 +745,7 @@ public class GroupManagerTestCase
     DN groupDN = DN.valueOf("cn=Test Group of Names,ou=Groups,o=test");
     Group groupInstance = groupManager.getGroupInstance(groupDN);
     assertNotNull(groupInstance);
-    assertEquals(groupInstance.getGroupDN(), groupDN);
+    TestCaseUtils.assertObjectEquals(groupInstance.getGroupDN(), groupDN);
     assertFalse(groupInstance.getMembers().hasMoreMembers());
 
 
@@ -841,7 +841,7 @@ public class GroupManagerTestCase
 
     Group groupInstance = groupManager.getGroupInstance(groupDN);
     assertNotNull(groupInstance);
-    assertEquals(groupInstance.getGroupDN(), groupDN);
+    TestCaseUtils.assertObjectEquals(groupInstance.getGroupDN(), groupDN);
     assertTrue(groupInstance.isMember(user1DN));
     assertTrue(groupInstance.isMember(user2DN));
     assertFalse(groupInstance.isMember(user3DN));
@@ -858,7 +858,7 @@ public class GroupManagerTestCase
                                           SearchScope.WHOLE_SUBTREE, filter);
     assertTrue(memberList.hasMoreMembers());
     DN memberDN = memberList.nextMemberDN();
-    assertEquals(memberDN, user1DN);
+    TestCaseUtils.assertObjectEquals(memberDN, user1DN);
     assertFalse(memberList.hasMoreMembers());
 
     filter = SearchFilter.createFilterFromString("(uid=user.3)");
@@ -876,7 +876,7 @@ public class GroupManagerTestCase
 
     groupInstance = groupManager.getGroupInstance(groupDN);
     assertNotNull(groupInstance);
-    assertEquals(groupInstance.getGroupDN(), groupDN);
+    TestCaseUtils.assertObjectEquals(groupInstance.getGroupDN(), groupDN);
     assertTrue(groupInstance.isMember(user1DN));
     assertFalse(groupInstance.isMember(user2DN));
     assertTrue(groupInstance.isMember(user3DN));
@@ -929,7 +929,7 @@ public class GroupManagerTestCase
     DN groupDN = DN.valueOf("cn=Test Group of Unique Names,ou=Groups,o=test");
     Group groupInstance = groupManager.getGroupInstance(groupDN);
     assertNotNull(groupInstance);
-    assertEquals(groupInstance.getGroupDN(), groupDN);
+    TestCaseUtils.assertObjectEquals(groupInstance.getGroupDN(), groupDN);
     assertFalse(groupInstance.getMembers().hasMoreMembers());
 
 
@@ -1025,7 +1025,7 @@ public class GroupManagerTestCase
 
     Group groupInstance = groupManager.getGroupInstance(groupDN);
     assertNotNull(groupInstance);
-    assertEquals(groupInstance.getGroupDN(), groupDN);
+    TestCaseUtils.assertObjectEquals(groupInstance.getGroupDN(), groupDN);
     assertTrue(groupInstance.isMember(user1DN));
     assertTrue(groupInstance.isMember(user2DN));
     assertFalse(groupInstance.isMember(user3DN));
@@ -1042,7 +1042,7 @@ public class GroupManagerTestCase
                                           SearchScope.WHOLE_SUBTREE, filter);
     assertTrue(memberList.hasMoreMembers());
     DN memberDN = memberList.nextMemberDN();
-    assertEquals(memberDN, user1DN);
+    TestCaseUtils.assertObjectEquals(memberDN, user1DN);
     assertFalse(memberList.hasMoreMembers());
 
     filter = SearchFilter.createFilterFromString("(uid=user.3)");
@@ -1060,7 +1060,7 @@ public class GroupManagerTestCase
 
     groupInstance = groupManager.getGroupInstance(groupDN);
     assertNotNull(groupInstance);
-    assertEquals(groupInstance.getGroupDN(), groupDN);
+    TestCaseUtils.assertObjectEquals(groupInstance.getGroupDN(), groupDN);
     assertTrue(groupInstance.isMember(user1DN));
     assertFalse(groupInstance.isMember(user2DN));
     assertTrue(groupInstance.isMember(user3DN));
@@ -1113,7 +1113,7 @@ public class GroupManagerTestCase
     DN groupDN = DN.valueOf("cn=Test Group of Entries,ou=Groups,o=test");
     Group groupInstance = groupManager.getGroupInstance(groupDN);
     assertNotNull(groupInstance);
-    assertEquals(groupInstance.getGroupDN(), groupDN);
+    TestCaseUtils.assertObjectEquals(groupInstance.getGroupDN(), groupDN);
     assertFalse(groupInstance.getMembers().hasMoreMembers());
 
 
@@ -1183,7 +1183,7 @@ public class GroupManagerTestCase
 
     Group groupInstance = groupManager.getGroupInstance(groupDN);
     assertNotNull(groupInstance);
-    assertEquals(groupInstance.getGroupDN(), groupDN);
+    TestCaseUtils.assertObjectEquals(groupInstance.getGroupDN(), groupDN);
     assertTrue(groupInstance.isMember(user1DN));
 
 
@@ -1200,7 +1200,7 @@ public class GroupManagerTestCase
 
     groupInstance = groupManager.getGroupInstance(newDN);
     assertNotNull(groupInstance);
-    assertEquals(groupInstance.getGroupDN(), newDN);
+    TestCaseUtils.assertObjectEquals(groupInstance.getGroupDN(), newDN);
     assertTrue(groupInstance.isMember(user1DN));
 
 
@@ -1523,7 +1523,7 @@ public class GroupManagerTestCase
     DN groupDN = DN.valueOf("cn=Test Group of Unique Names,ou=Groups,o=test");
     Group groupInstance = groupManager.getGroupInstance(groupDN);
     assertNotNull(groupInstance);
-    assertEquals(groupInstance.getGroupDN(), groupDN);
+    TestCaseUtils.assertObjectEquals(groupInstance.getGroupDN(), groupDN);
 
 
     // Use a member list to iterate across the member DNs with no filter.
@@ -1660,7 +1660,7 @@ public class GroupManagerTestCase
 
     Group groupInstance = groupManager.getGroupInstance(groupDN);
     assertNotNull(groupInstance);
-    assertEquals(groupInstance.getGroupDN(), groupDN);
+    TestCaseUtils.assertObjectEquals(groupInstance.getGroupDN(), groupDN);
     assertTrue(groupInstance.isMember(user1DN));
     assertTrue(groupInstance.isMember(user2DN));
     assertFalse(groupInstance.isMember(user3DN));

--- a/opendj-server-legacy/src/test/java/org/opends/server/core/ModifyOperationTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/core/ModifyOperationTestCase.java
@@ -33,7 +33,6 @@ import static org.forgerock.opendj.ldap.schema.CoreSchema.getUserCertificateAttr
 import static org.forgerock.opendj.ldap.schema.CoreSchema.getUserPasswordAttributeType;
 import static org.opends.server.TestCaseUtils.TEST_BACKEND_ID;
 import static org.opends.server.TestCaseUtils.applyModifications;
-import static org.opends.server.TestCaseUtils.assertNotEquals;
 import static org.opends.server.TestCaseUtils.getServerContext;
 import static org.opends.server.core.AddOperationTestCase.setWritabilityMode;
 import static org.opends.server.protocols.internal.InternalClientConnection.getRootConnection;
@@ -47,6 +46,7 @@ import static org.opends.server.util.CollectionUtils.newArrayList;
 import static org.opends.server.util.ServerConstants.OID_PERMISSIVE_MODIFY_CONTROL;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 

--- a/opendj-server-legacy/src/test/java/org/opends/server/core/RejectUnauthReqTests.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/core/RejectUnauthReqTests.java
@@ -16,13 +16,13 @@
  */
 package org.opends.server.core;
 
-import static org.opends.server.TestCaseUtils.assertNotEquals;
 import static org.opends.server.TestCaseUtils.getServer;
 import static org.opends.server.protocols.internal.InternalClientConnection.getRootConnection;
 import static org.opends.server.types.NullOutputStream.nullPrintStream;
 import static org.opends.server.util.ServerConstants.OID_WHO_AM_I_REQUEST;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.fail;

--- a/opendj-server-legacy/src/test/java/org/opends/server/core/SearchOperationTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/core/SearchOperationTestCase.java
@@ -968,7 +968,7 @@ public class SearchOperationTestCase extends OperationTestCase
     assertThat(entries).hasSize(1);
 
     Entry entry = entries.getFirst();
-    assertEquals(entry.getName(), userDN);
+    TestCaseUtils.assertObjectEquals(entry.getName(), userDN);
 
     // Check real attributes and virtual (operational) attributes.
     List<String> messages = new LinkedList<>();
@@ -1155,7 +1155,7 @@ public class SearchOperationTestCase extends OperationTestCase
     assertThat(entries).hasSize(1);
 
     Entry entry = entries.getFirst();
-    assertEquals(entry.getName(), userDN);
+    TestCaseUtils.assertObjectEquals(entry.getName(), userDN);
 
     // Check all expected attributes are present and have the user requested name.
     assertThat(getAttributeNames(entry)).containsAll(expectedAttributes);
@@ -1216,7 +1216,7 @@ public class SearchOperationTestCase extends OperationTestCase
           new LinkedHashSet<>(requestedAttributes));
 
     SearchResultEntryProtocolOp entry = searchExternalForSingleEntry(searchRequest, null);
-    assertEquals(entry.getDN(), userDN);
+    TestCaseUtils.assertObjectEquals(entry.getDN(), userDN);
 
     // Check all expected attributes are present and have the user requested name.
     assertThat(getAttributeNames(entry)).containsAll(expectedAttributes);

--- a/opendj-server-legacy/src/test/java/org/opends/server/core/SubentryPasswordPolicyTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/core/SubentryPasswordPolicyTestCase.java
@@ -16,11 +16,11 @@
  */
 package org.opends.server.core;
 
-import static org.opends.server.TestCaseUtils.assertNotEquals;
 import static org.opends.server.TestCaseUtils.getServerContext;
 import static org.opends.server.protocols.internal.InternalClientConnection.getRootConnection;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;

--- a/opendj-server-legacy/src/test/java/org/opends/server/crypto/GetSymmetricKeyExtendedOperationTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/crypto/GetSymmetricKeyExtendedOperationTestCase.java
@@ -16,7 +16,6 @@
  */
 package org.opends.server.crypto;
 
-import static org.opends.server.TestCaseUtils.assertNotEquals;
 import static org.opends.server.config.ConfigConstants.ATTR_CRYPTO_CIPHER_TRANSFORMATION_NAME;
 import static org.opends.server.config.ConfigConstants.ATTR_CRYPTO_KEY_COMPROMISED_TIME;
 import static org.opends.server.config.ConfigConstants.ATTR_CRYPTO_KEY_LENGTH_BITS;
@@ -26,6 +25,7 @@ import static org.opends.server.protocols.internal.InternalClientConnection.getR
 import static org.opends.server.protocols.internal.Requests.newSearchRequest;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotEquals;
 
 import org.forgerock.opendj.ldap.ByteString;
 import org.forgerock.opendj.ldap.DN;

--- a/opendj-server-legacy/src/test/java/org/opends/server/extensions/CRAMMD5SASLMechanismHandlerTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/extensions/CRAMMD5SASLMechanismHandlerTestCase.java
@@ -16,11 +16,11 @@
  */
 package org.opends.server.extensions;
 
-import static org.opends.server.TestCaseUtils.assertNotEquals;
 import static org.opends.server.types.NullOutputStream.nullPrintStream;
 import static org.opends.server.util.ServerConstants.SASL_MECHANISM_CRAM_MD5;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertTrue;
 
 import java.util.List;

--- a/opendj-server-legacy/src/test/java/org/opends/server/extensions/DigestMD5SASLMechanismHandlerTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/extensions/DigestMD5SASLMechanismHandlerTestCase.java
@@ -16,12 +16,12 @@
  */
 package org.opends.server.extensions;
 
-import static org.opends.server.TestCaseUtils.assertNotEquals;
 import static org.opends.server.protocols.internal.InternalClientConnection.getRootConnection;
 import static org.opends.server.types.NullOutputStream.nullPrintStream;
 import static org.opends.server.util.ServerConstants.SASL_MECHANISM_DIGEST_MD5;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertTrue;
 
 import java.util.List;

--- a/opendj-server-legacy/src/test/java/org/opends/server/extensions/ExactMatchIdentityMapperTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/extensions/ExactMatchIdentityMapperTestCase.java
@@ -311,7 +311,7 @@ public class ExactMatchIdentityMapperTestCase
     // successfully.
     Entry mappedEntry = mapper.getEntryForID("test");
     assertNotNull(mappedEntry);
-    assertEquals(mappedEntry.getName(), DN.valueOf("uid=test,o=test"));
+    TestCaseUtils.assertObjectEquals(mappedEntry.getName(), DN.valueOf("uid=test,o=test"));
 
 
     mapper.finalizeIdentityMapper();
@@ -365,7 +365,7 @@ public class ExactMatchIdentityMapperTestCase
     // successfully.
     Entry mappedEntry = mapper.getEntryForID("test");
     assertNotNull(mappedEntry);
-    assertEquals(mappedEntry.getName(), DN.valueOf("uid=test,o=test"));
+    TestCaseUtils.assertObjectEquals(mappedEntry.getName(), DN.valueOf("uid=test,o=test"));
 
 
     mapper.finalizeIdentityMapper();
@@ -590,7 +590,7 @@ public class ExactMatchIdentityMapperTestCase
     // successfully.
     Entry mappedEntry = mapper.getEntryForID("foo");
     assertNotNull(mappedEntry);
-    assertEquals(mappedEntry.getName(), DN.valueOf("uid=foo,o=test"));
+    TestCaseUtils.assertObjectEquals(mappedEntry.getName(), DN.valueOf("uid=foo,o=test"));
 
 
     mapper.finalizeIdentityMapper();
@@ -644,7 +644,7 @@ public class ExactMatchIdentityMapperTestCase
     // successfully.
     Entry mappedEntry = mapper.getEntryForID("bar");
     assertNotNull(mappedEntry);
-    assertEquals(mappedEntry.getName(), DN.valueOf("uid=foo,o=test"));
+    TestCaseUtils.assertObjectEquals(mappedEntry.getName(), DN.valueOf("uid=foo,o=test"));
 
 
     mapper.finalizeIdentityMapper();
@@ -742,7 +742,7 @@ public class ExactMatchIdentityMapperTestCase
     // does not.
     Entry mappedEntry = mapper.getEntryForID("test");
     assertNotNull(mappedEntry);
-    assertEquals(mappedEntry.getName(), DN.valueOf("uid=test,o=test"));
+    TestCaseUtils.assertObjectEquals(mappedEntry.getName(), DN.valueOf("uid=test,o=test"));
 
     mappedEntry = mapper.getEntryForID("test user");
     assertNull(mappedEntry);
@@ -760,7 +760,7 @@ public class ExactMatchIdentityMapperTestCase
 
     mappedEntry = mapper.getEntryForID("test user");
     assertNotNull(mappedEntry);
-    assertEquals(mappedEntry.getName(), DN.valueOf("uid=test,o=test"));
+    TestCaseUtils.assertObjectEquals(mappedEntry.getName(), DN.valueOf("uid=test,o=test"));
 
 
     // Change the configuration back to the way it was.
@@ -772,7 +772,7 @@ public class ExactMatchIdentityMapperTestCase
     // Verify that the original matching pattern is back.
     mappedEntry = mapper.getEntryForID("test");
     assertNotNull(mappedEntry);
-    assertEquals(mappedEntry.getName(), DN.valueOf("uid=test,o=test"));
+    TestCaseUtils.assertObjectEquals(mappedEntry.getName(), DN.valueOf("uid=test,o=test"));
 
     mappedEntry = mapper.getEntryForID("test user");
     assertNull(mappedEntry);
@@ -814,7 +814,7 @@ public class ExactMatchIdentityMapperTestCase
     // Verify that we can retrieve the user.
     Entry mappedEntry = mapper.getEntryForID("test");
     assertNotNull(mappedEntry);
-    assertEquals(mappedEntry.getName(), DN.valueOf("uid=test,o=test"));
+    TestCaseUtils.assertObjectEquals(mappedEntry.getName(), DN.valueOf("uid=test,o=test"));
 
 
     // Create a modification to set the map base DN to "dc=example,dc=com".
@@ -837,7 +837,7 @@ public class ExactMatchIdentityMapperTestCase
     // Verify that we can retrieve the user again.
     mappedEntry = mapper.getEntryForID("test");
     assertNotNull(mappedEntry);
-    assertEquals(mappedEntry.getName(), DN.valueOf("uid=test,o=test"));
+    TestCaseUtils.assertObjectEquals(mappedEntry.getName(), DN.valueOf("uid=test,o=test"));
 
 
     // Change the configuration back to its original setting.
@@ -849,7 +849,7 @@ public class ExactMatchIdentityMapperTestCase
     // Verify that we can still retrieve the user.
     mappedEntry = mapper.getEntryForID("test");
     assertNotNull(mappedEntry);
-    assertEquals(mappedEntry.getName(), DN.valueOf("uid=test,o=test"));
+    TestCaseUtils.assertObjectEquals(mappedEntry.getName(), DN.valueOf("uid=test,o=test"));
   }
 
   /**

--- a/opendj-server-legacy/src/test/java/org/opends/server/extensions/ExternalSASLMechanismHandlerTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/extensions/ExternalSASLMechanismHandlerTestCase.java
@@ -278,7 +278,7 @@ public class ExternalSASLMechanismHandlerTestCase
         Connection conn = factory.getConnection())
     {
       BindResult result = conn.bind(Requests.newExternalSASLBindRequest());
-      TestCaseUtils.assertNotEquals(result.getResultCode(), ResultCode.SUCCESS);
+      assertNotEquals(result.getResultCode(), ResultCode.SUCCESS);
     }
  }
 

--- a/opendj-server-legacy/src/test/java/org/opends/server/extensions/IsMemberOfVirtualAttributeProviderTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/extensions/IsMemberOfVirtualAttributeProviderTestCase.java
@@ -854,9 +854,9 @@ public class IsMemberOfVirtualAttributeProviderTestCase
     List<SearchResultEntry> entries = searchOperation.getSearchEntries();
     assertEquals(entries.size(), 2, "Expecting 2 entries, but got " + entries.size());
     // First direct members
-    assertEquals(entries.get(0).getName(), DN.valueOf("cn=test group 1,ou=groups,o=test"));
+    TestCaseUtils.assertObjectEquals(entries.get(0).getName(), DN.valueOf("cn=test group 1,ou=groups,o=test"));
     // Then indirect members
-    assertEquals(entries.get(1).getName(), DN.valueOf("uid=test.user,ou=people,o=test"));
+    TestCaseUtils.assertObjectEquals(entries.get(1).getName(), DN.valueOf("uid=test.user,ou=people,o=test"));
 
     delete("cn=test group 1,ou=groups,o=test",
         "cn=test group 2,ou=groups,o=test",

--- a/opendj-server-legacy/src/test/java/org/opends/server/extensions/RegularExpressionIdentityMapperTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/extensions/RegularExpressionIdentityMapperTestCase.java
@@ -204,7 +204,7 @@ public class RegularExpressionIdentityMapperTestCase
     // successfully.
     Entry mappedEntry = mapper.getEntryForID("test@example.com");
     assertNotNull(mappedEntry);
-    assertEquals(mappedEntry.getName(), DN.valueOf("uid=test,o=test"));
+    TestCaseUtils.assertObjectEquals(mappedEntry.getName(), DN.valueOf("uid=test,o=test"));
 
     mapper.finalizeIdentityMapper();
   }
@@ -261,7 +261,7 @@ public class RegularExpressionIdentityMapperTestCase
     // successfully.
     Entry mappedEntry = mapper.getEntryForID("test@example.com");
     assertNotNull(mappedEntry);
-    assertEquals(mappedEntry.getName(), DN.valueOf("uid=test,o=test"));
+    TestCaseUtils.assertObjectEquals(mappedEntry.getName(), DN.valueOf("uid=test,o=test"));
 
     mapper.finalizeIdentityMapper();
   }
@@ -318,7 +318,7 @@ public class RegularExpressionIdentityMapperTestCase
     // successfully.
     Entry mappedEntry = mapper.getEntryForID("test@example.com");
     assertNotNull(mappedEntry);
-    assertEquals(mappedEntry.getName(), DN.valueOf("uid=test,o=test"));
+    TestCaseUtils.assertObjectEquals(mappedEntry.getName(), DN.valueOf("uid=test,o=test"));
 
     mapper.finalizeIdentityMapper();
   }
@@ -432,7 +432,7 @@ public class RegularExpressionIdentityMapperTestCase
     // successfully.
     Entry mappedEntry = mapper.getEntryForID("test@example.com");
     assertNotNull(mappedEntry);
-    assertEquals(mappedEntry.getName(), DN.valueOf("uid=test,o=test"));
+    TestCaseUtils.assertObjectEquals(mappedEntry.getName(), DN.valueOf("uid=test,o=test"));
 
     mapper.finalizeIdentityMapper();
   }
@@ -488,7 +488,7 @@ public class RegularExpressionIdentityMapperTestCase
     // successfully.
     Entry mappedEntry = mapper.getEntryForID("test");
     assertNotNull(mappedEntry);
-    assertEquals(mappedEntry.getName(), DN.valueOf("uid=test,o=test"));
+    TestCaseUtils.assertObjectEquals(mappedEntry.getName(), DN.valueOf("uid=test,o=test"));
 
     mapper.finalizeIdentityMapper();
   }
@@ -542,7 +542,7 @@ public class RegularExpressionIdentityMapperTestCase
     // successfully.
     Entry mappedEntry = mapper.getEntryForID("test@example.com");
     assertNotNull(mappedEntry);
-    assertEquals(mappedEntry.getName(), DN.valueOf("uid=test,o=test"));
+    TestCaseUtils.assertObjectEquals(mappedEntry.getName(), DN.valueOf("uid=test,o=test"));
 
     mapper.finalizeIdentityMapper();
   }
@@ -597,7 +597,7 @@ public class RegularExpressionIdentityMapperTestCase
     // successfully.
     Entry mappedEntry = mapper.getEntryForID("test");
     assertNotNull(mappedEntry);
-    assertEquals(mappedEntry.getName(), DN.valueOf("uid=test@example.com,o=test"));
+    TestCaseUtils.assertObjectEquals(mappedEntry.getName(), DN.valueOf("uid=test@example.com,o=test"));
 
     mapper.finalizeIdentityMapper();
   }

--- a/opendj-server-legacy/src/test/java/org/opends/server/extensions/VirtualStaticGroupTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/extensions/VirtualStaticGroupTestCase.java
@@ -388,8 +388,8 @@ public class VirtualStaticGroupTestCase
     assertTrue(g.isMember(u1));
 
     assertNotNull(g.getGroupDefinitionFilter());
-    assertEquals(g.getGroupDN(), vmda);
-    assertEquals(g.getTargetGroupDN(), da);
+    TestCaseUtils.assertObjectEquals(g.getGroupDN(), vmda);
+    TestCaseUtils.assertObjectEquals(g.getTargetGroupDN(), da);
     assertFalse(g.supportsNestedGroups());
     assertTrue(g.getNestedGroupDNs().isEmpty());
     assertFalse(g.mayAlterMemberList());
@@ -461,8 +461,8 @@ public class VirtualStaticGroupTestCase
     assertNotNull(g);
 
     assertNotNull(g.getGroupDefinitionFilter());
-    assertEquals(g.getGroupDN(), vn);
-    assertEquals(g.getTargetGroupDN(), ne);
+    TestCaseUtils.assertObjectEquals(g.getGroupDN(), vn);
+    TestCaseUtils.assertObjectEquals(g.getTargetGroupDN(), ne);
     assertFalse(g.supportsNestedGroups());
     assertTrue(g.getNestedGroupDNs().isEmpty());
     assertFalse(g.mayAlterMemberList());

--- a/opendj-server-legacy/src/test/java/org/opends/server/protocols/ldap/TestAddResponseProtocolOp.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/protocols/ldap/TestAddResponseProtocolOp.java
@@ -114,7 +114,7 @@ public class TestAddResponseProtocolOp extends DirectoryServerTestCase {
                                            referralURLs);
     assertEquals(addResponse.getErrorMessage(), resultMsg);
     assertEquals(addResponse.getResultCode(), resultCode);
-    assertEquals(addResponse.getMatchedDN(), dn);
+    TestCaseUtils.assertObjectEquals(addResponse.getMatchedDN(), dn);
     assertEquals(addResponse.getReferralURLs(), referralURLs);
   }
 

--- a/opendj-server-legacy/src/test/java/org/opends/server/protocols/ldap/TestBindResponseProtocolOp.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/protocols/ldap/TestBindResponseProtocolOp.java
@@ -109,7 +109,7 @@ public class TestBindResponseProtocolOp  extends LdapTestCase {
       assertTrue(protocolOp instanceof BindResponseProtocolOp);
       BindResponseProtocolOp bindResponse = (BindResponseProtocolOp)protocolOp;
       assertEquals(bindResponse.getResultCode(), okCode.intValue());
-      assertEquals(bindResponse.getMatchedDN(), responseDn);
+      TestCaseUtils.assertObjectEquals(bindResponse.getMatchedDN(), responseDn);
       assertEquals(bindResponse.getErrorMessage().toString(), message.toString());
       assertNull(bindResponse.getReferralURLs());
       assertNull(bindResponse.getServerSASLCredentials());
@@ -156,7 +156,7 @@ public class TestBindResponseProtocolOp  extends LdapTestCase {
       assertTrue(protocolOp instanceof BindResponseProtocolOp);
       BindResponseProtocolOp bindResponse = (BindResponseProtocolOp)protocolOp;
       assertEquals(bindResponse.getResultCode(), okCode.intValue());
-      assertEquals(bindResponse.getMatchedDN(), responseDn);
+      TestCaseUtils.assertObjectEquals(bindResponse.getMatchedDN(), responseDn);
       assertEquals(bindResponse.getErrorMessage().toString(), message.toString());
       assertNull(bindResponse.getReferralURLs());
       assertNull(bindResponse.getServerSASLCredentials());
@@ -231,6 +231,6 @@ public class TestBindResponseProtocolOp  extends LdapTestCase {
         assertTrue(list1.equals(list2));
         DN dn1=saslOkOp.getMatchedDN();
         DN dn2=saslOkResp.getMatchedDN();
-        assertEquals(dn1, dn2);
+        TestCaseUtils.assertObjectEquals(dn1, dn2);
     }
 }

--- a/opendj-server-legacy/src/test/java/org/opends/server/protocols/ldap/TestCompareResponseProtocolOp.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/protocols/ldap/TestCompareResponseProtocolOp.java
@@ -115,7 +115,7 @@ public class TestCompareResponseProtocolOp extends LdapTestCase
                                                   referralURLs);
     assertEquals(compareResponse.getErrorMessage(), resultMsg);
     assertEquals(compareResponse.getResultCode(), resultCode);
-    assertEquals(compareResponse.getMatchedDN(), dn);
+    TestCaseUtils.assertObjectEquals(compareResponse.getMatchedDN(), dn);
     assertEquals(compareResponse.getReferralURLs(), referralURLs);
   }
 

--- a/opendj-server-legacy/src/test/java/org/opends/server/protocols/ldap/TestDeleteResponseProtocolOp.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/protocols/ldap/TestDeleteResponseProtocolOp.java
@@ -116,7 +116,7 @@ public class TestDeleteResponseProtocolOp extends LdapTestCase
                                             referralURLs);
     assertEquals(deleteResponse.getErrorMessage(), resultMsg);
     assertEquals(deleteResponse.getResultCode(), resultCode);
-    assertEquals(deleteResponse.getMatchedDN(), dn);
+    TestCaseUtils.assertObjectEquals(deleteResponse.getMatchedDN(), dn);
     assertEquals(deleteResponse.getReferralURLs(), referralURLs);
   }
 

--- a/opendj-server-legacy/src/test/java/org/opends/server/protocols/ldap/TestModifyDNResponseProtocolOp.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/protocols/ldap/TestModifyDNResponseProtocolOp.java
@@ -116,7 +116,7 @@ public class TestModifyDNResponseProtocolOp extends DirectoryServerTestCase
                                                     referralURLs);
     assertEquals(modifyResponse.getErrorMessage(), resultMsg);
     assertEquals(modifyResponse.getResultCode(), resultCode);
-    assertEquals(modifyResponse.getMatchedDN(), dn);
+    TestCaseUtils.assertObjectEquals(modifyResponse.getMatchedDN(), dn);
     assertEquals(modifyResponse.getReferralURLs(), referralURLs);
   }
 

--- a/opendj-server-legacy/src/test/java/org/opends/server/protocols/ldap/TestModifyResponseProtocolOp.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/protocols/ldap/TestModifyResponseProtocolOp.java
@@ -115,7 +115,7 @@ public class TestModifyResponseProtocolOp extends LdapTestCase
                                                   referralURLs);
     assertEquals(modifyResponse.getErrorMessage(), resultMsg);
     assertEquals(modifyResponse.getResultCode(), resultCode);
-    assertEquals(modifyResponse.getMatchedDN(), dn);
+    TestCaseUtils.assertObjectEquals(modifyResponse.getMatchedDN(), dn);
     assertEquals(modifyResponse.getReferralURLs(), referralURLs);
   }
 

--- a/opendj-server-legacy/src/test/java/org/opends/server/protocols/ldap/TestSearchResultEntryProtocolOp.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/protocols/ldap/TestSearchResultEntryProtocolOp.java
@@ -202,7 +202,7 @@ public class TestSearchResultEntryProtocolOp extends LdapTestCase
     SearchResultEntryProtocolOp decodedProtocolOp =
         (SearchResultEntryProtocolOp)LDAPReader.readProtocolOp(reader);
 
-    assertEquals(decodedProtocolOp.getDN(), protocolOp.getDN());
+    TestCaseUtils.assertObjectEquals(decodedProtocolOp.getDN(), protocolOp.getDN());
     assertTrue(testEqual(decodedProtocolOp.getAttributes(),
                          protocolOp.getAttributes()));
   }

--- a/opendj-server-legacy/src/test/java/org/opends/server/replication/ProtocolWindowTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/replication/ProtocolWindowTest.java
@@ -139,8 +139,7 @@ public class ProtocolWindowTest extends ReplicationTestCase
       assertEquals(OperationType.ADD.compareTo(receivedOp.getOperationType()), 0,
           "The received Replication message is not an ADD msg");
 
-      assertEquals(addMsg.getDN(), personEntry.getName(),
-        "The received ADD Replication message is not for the excepted DN");
+      TestCaseUtils.assertObjectEquals(addMsg.getDN(), personEntry.getName(), "The received ADD Replication message is not for the excepted DN");
 
       // send (2 * window + replicationServer queue) modify operations
       // so that window + replicationServer queue get stuck in the replicationServer queue

--- a/opendj-server-legacy/src/test/java/org/opends/server/replication/SchemaReplicationTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/replication/SchemaReplicationTest.java
@@ -266,7 +266,7 @@ public class SchemaReplicationTest extends ReplicationTestCase
   private void assertModReceived(Modification mod, final DN baseDN, ModifyMsg modMsg) throws Exception
   {
     Operation receivedOp = modMsg.createOperation(connection);
-    assertEquals(modMsg.getDN(), baseDN, "The received message is not for cn=schema");
+    TestCaseUtils.assertObjectEquals(modMsg.getDN(), baseDN, "The received message is not for cn=schema");
     Assertions.assertThat(receivedOp).isInstanceOf(ModifyOperation.class);
     ModifyOperation receivedModifyOperation = (ModifyOperation) receivedOp;
 

--- a/opendj-server-legacy/src/test/java/org/opends/server/replication/StressTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/replication/StressTest.java
@@ -96,8 +96,7 @@ public class StressTest extends ReplicationTestCase
         Operation receivedOp = addMsg.createOperation(connection);
         assertEquals(receivedOp.getOperationType(), OperationType.ADD,
         "The received replication message is not an ADD msg");
-        assertEquals(addMsg.getDN(), personEntry.getName(),
-        "The received ADD replication message is not for the excepted DN");
+        TestCaseUtils.assertObjectEquals(addMsg.getDN(), personEntry.getName(), "The received ADD replication message is not for the excepted DN");
       }
 
       reader = new BrokerReader(broker);

--- a/opendj-server-legacy/src/test/java/org/opends/server/replication/UpdateOperationTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/replication/UpdateOperationTest.java
@@ -22,7 +22,6 @@ import static org.forgerock.opendj.ldap.ModificationType.REPLACE;
 import static org.forgerock.opendj.ldap.requests.Requests.newModifyDNRequest;
 import static org.forgerock.opendj.ldap.schema.CoreSchema.getEntryUUIDAttributeType;
 import static org.opends.server.TestCaseUtils.TEST_ROOT_DN_STRING;
-import static org.opends.server.TestCaseUtils.assertNotEquals;
 import static org.opends.server.TestCaseUtils.getServerContext;
 import static org.opends.server.protocols.internal.InternalClientConnection.getRootConnection;
 import static org.opends.server.replication.plugin.LDAPReplicationDomain.DS_SYNC_CONFLICT;
@@ -30,6 +29,7 @@ import static org.opends.server.util.CollectionUtils.isEmpty;
 import static org.opends.server.util.CollectionUtils.newArrayList;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
@@ -1237,7 +1237,7 @@ public class UpdateOperationTest extends ReplicationTestCase
     final Operation receivedOp = opMsg.createOperation(connection);
     assertEquals(receivedOp.getOperationType(), opType,
         "The received replication message is not of corrct type. msg : " + opMsg);
-    assertEquals(opMsg.getDN(), expectedDN, "The received " + opType
+    TestCaseUtils.assertObjectEquals(opMsg.getDN(), expectedDN, "The received " + opType
         + " replication message is not for the expected DN : " + opMsg);
   }
 

--- a/opendj-server-legacy/src/test/java/org/opends/server/replication/plugin/FractionalReplicationTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/replication/plugin/FractionalReplicationTest.java
@@ -1223,7 +1223,7 @@ public class FractionalReplicationTest extends ReplicationTestCase {
        */
       Entry newEntry = getEntry(entry.getName(), TIMEOUT, true);
       assertNotNull(newEntry);
-      assertEquals(entry.getName(), newEntry.getName());
+      TestCaseUtils.assertObjectEquals(entry.getName(), newEntry.getName());
       assertTrue(newEntry.hasObjectClass(getInetOrgPersonObjectClass()));
       checkEntryAttributeValue(newEntry, "displayName", "ValueToBeKept");
 
@@ -1257,7 +1257,7 @@ public class FractionalReplicationTest extends ReplicationTestCase {
        */
       newEntry = getEntry(entry.getName(), TIMEOUT, true);
       assertNotNull(newEntry);
-      assertEquals(entry.getName(), newEntry.getName());
+      TestCaseUtils.assertObjectEquals(entry.getName(), newEntry.getName());
       assertTrue(newEntry.hasObjectClass(getInetOrgPersonObjectClass()));
       checkEntryAttributeValue(newEntry, "displayName", "ValueToBeKept");
       checkEntryAttributeValue(newEntry, "givenName", "ValueToBeKeptToo");
@@ -1312,7 +1312,7 @@ public class FractionalReplicationTest extends ReplicationTestCase {
        */
       Entry newEntry = getEntry(entry.getName(), TIMEOUT, true);
       assertNotNull(newEntry);
-      assertEquals(entry.getName(), newEntry.getName());
+      TestCaseUtils.assertObjectEquals(entry.getName(), newEntry.getName());
       assertTrue(newEntry.hasObjectClass(getInetOrgPersonObjectClass()));
       checkEntryAttributeValue(newEntry, "displayName", "ValueToBeKept");
       checkEntryAttributeValue(newEntry, "carLicense", "cirLicenseValue");
@@ -1348,7 +1348,7 @@ public class FractionalReplicationTest extends ReplicationTestCase {
        */
       newEntry = getEntry(entry.getName(), TIMEOUT, true);
       assertNotNull(newEntry);
-      assertEquals(entry.getName(), newEntry.getName());
+      TestCaseUtils.assertObjectEquals(entry.getName(), newEntry.getName());
       assertTrue(newEntry.hasObjectClass(getInetOrgPersonObjectClass()));
       checkEntryAttributeValue(newEntry, "displayName", "ValueToBeKept");
       checkEntryAttributeValue(newEntry, "description", "ValueToBeKeptToo");
@@ -1402,7 +1402,7 @@ public class FractionalReplicationTest extends ReplicationTestCase {
       // check that entry has been created and has attribute values from RDN
       Entry newEntry = getEntry(entry.getName(), TIMEOUT, true);
       assertNotNull(newEntry);
-      assertEquals(entry.getName(), newEntry.getName());
+      TestCaseUtils.assertObjectEquals(entry.getName(), newEntry.getName());
       assertTrue(newEntry.hasObjectClass(getInetOrgPersonObjectClass()));
       checkEntryAttributeValue(newEntry, "displayName", "ValueToBeKept");
       checkEntryAttributeValue(newEntry, "givenName", "ValueToBeRemoved");
@@ -1424,7 +1424,7 @@ public class FractionalReplicationTest extends ReplicationTestCase {
       // check that entry has been renamed and has only attribute left in the new RDN
       newEntry = getEntry(newEntryDn, TIMEOUT, true);
       assertNotNull(newEntry);
-      assertEquals(newEntryDn, newEntry.getName());
+      TestCaseUtils.assertObjectEquals(newEntryDn, newEntry.getName());
       assertTrue(newEntry.hasObjectClass(getInetOrgPersonObjectClass()));
       checkEntryAttributeValue(newEntry, "displayName", "ValueToBeKept");
       assertThat(newEntry.getAllAttributes("givenName")).isEmpty();
@@ -1483,7 +1483,7 @@ public class FractionalReplicationTest extends ReplicationTestCase {
       // check that entry has been created and has attribute values from RDN
       Entry newEntry = getEntry(entry.getName(), TIMEOUT, true);
       assertNotNull(newEntry);
-      assertEquals(entry.getName(), newEntry.getName());
+      TestCaseUtils.assertObjectEquals(entry.getName(), newEntry.getName());
       assertTrue(newEntry.hasObjectClass(getInetOrgPersonObjectClass()));
       checkEntryAttributeValue(newEntry, "displayName", "ValueToBeKept");
       checkEntryAttributeValue(newEntry, "description", "ValueToBeRemoved");
@@ -1505,7 +1505,7 @@ public class FractionalReplicationTest extends ReplicationTestCase {
       // check that entry has been renamed and has only attribute left in the * new RDN
       newEntry = getEntry(newEntryDn, TIMEOUT, true);
       assertNotNull(newEntry);
-      assertEquals(newEntryDn, newEntry.getName());
+      TestCaseUtils.assertObjectEquals(newEntryDn, newEntry.getName());
       assertTrue(newEntry.hasObjectClass(getInetOrgPersonObjectClass()));
       checkEntryAttributeValue(newEntry, "displayName", "ValueToBeKept");
       assertThat(newEntry.getAllAttributes("description")).isEmpty();

--- a/opendj-server-legacy/src/test/java/org/opends/server/replication/plugin/HistoricalCsnOrderingTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/replication/plugin/HistoricalCsnOrderingTest.java
@@ -300,19 +300,19 @@ public class HistoricalCsnOrderingTest extends ReplicationTestCase
     assertEquals(opList.size(), 5, "buildAndPublishMissingChanges should return 5 operations");
     ReplicationMsg msg = opList.removeFirst();
     assertEquals(msg.getClass(), AddMsg.class);
-    assertEquals(((LDAPUpdateMsg) msg).getDN(), dnTest1);
+    TestCaseUtils.assertObjectEquals(((LDAPUpdateMsg) msg).getDN(), dnTest1);
     msg = opList.removeFirst();
     assertEquals(msg.getClass(), DeleteMsg.class);
-    assertEquals(((LDAPUpdateMsg) msg).getDN(), dnTest3);
+    TestCaseUtils.assertObjectEquals(((LDAPUpdateMsg) msg).getDN(), dnTest3);
     msg = opList.removeFirst();
     assertEquals(msg.getClass(), AddMsg.class);
-    assertEquals(((LDAPUpdateMsg) msg).getDN(), dnTest2);
+    TestCaseUtils.assertObjectEquals(((LDAPUpdateMsg) msg).getDN(), dnTest2);
     msg = opList.removeFirst();
     assertEquals(msg.getClass(), ModifyMsg.class);
-    assertEquals(((LDAPUpdateMsg) msg).getDN(), dnTest2);
+    TestCaseUtils.assertObjectEquals(((LDAPUpdateMsg) msg).getDN(), dnTest2);
     msg = opList.removeFirst();
     assertEquals(msg.getClass(), ModifyMsg.class);
-    assertEquals(((LDAPUpdateMsg) msg).getDN(), dnTest1);
+    TestCaseUtils.assertObjectEquals(((LDAPUpdateMsg) msg).getDN(), dnTest1);
     }
     finally
     {

--- a/opendj-server-legacy/src/test/java/org/opends/server/replication/plugin/HistoricalTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/replication/plugin/HistoricalTest.java
@@ -179,7 +179,7 @@ public class HistoricalTest extends ReplicationTestCase
     // Check that encoding and decoding preserves the history information.
     EntryHistorical hist = EntryHistorical.newInstanceFromEntry(entry);
     assertEquals(hist.getLastPurgedValuesCount(),0);
-    assertEquals(hist.encodeAndPurge(), before);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), before);
 
     Thread.sleep(1000);
 
@@ -434,7 +434,7 @@ public class HistoricalTest extends ReplicationTestCase
     }
 
     Entry newEntry = DirectoryServer.getEntry(dn2);
-    assertEquals(entry.getName(), newEntry.getName());
+    TestCaseUtils.assertObjectEquals(entry.getName(), newEntry.getName());
   }
 
   /**
@@ -458,7 +458,7 @@ public class HistoricalTest extends ReplicationTestCase
         FakeAddOperation addOp = (FakeAddOperation) op;
         assertNotNull(addOp.getCSN());
         AddMsg addmsg = addOp.generateMessage();
-        assertEquals(dn1, addmsg.getDN());
+        TestCaseUtils.assertObjectEquals(dn1, addmsg.getDN());
         assertEquals(addmsg.getEntryUUID(), EntryHistorical.getEntryUUID(entry));
         String parentId = LDAPReplicationDomain.findEntryUUID(dn1.parent());
         assertEquals(addmsg.getParentEntryUUID(), parentId);

--- a/opendj-server-legacy/src/test/java/org/opends/server/replication/plugin/ModifyConflictTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/replication/plugin/ModifyConflictTest.java
@@ -29,6 +29,7 @@ import org.forgerock.opendj.ldap.ModificationType;
 import org.forgerock.opendj.ldap.schema.AttributeType;
 import org.forgerock.opendj.ldap.schema.CoreSchema;
 import org.forgerock.opendj.ldap.schema.ObjectClass;
+import org.opends.server.TestCaseUtils;
 import org.opends.server.core.ModifyOperationBasis;
 import org.opends.server.replication.ReplicationTestCase;
 import org.opends.server.replication.common.CSN;
@@ -89,14 +90,14 @@ public class ModifyConflictTest extends ReplicationTestCase
 
     // simulate a modify-replace done at time t10
     testModify(entry, hist, 10, true, newModification(REPLACE, DESCRIPTION, "init value"));
-    assertEquals(hist.encodeAndPurge(), repl);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), repl);
 
     /*
      * Now simulate an add at an earlier date that the previous replace
      * conflict resolution should remove it.
      */
     testModify(entry, hist, 1, false, newModification(ADD, DESCRIPTION, "older value"));
-    assertEquals(hist.encodeAndPurge(), repl);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), repl);
 
     /*
      * Now simulate an add at an earlier date that the previous replace
@@ -104,7 +105,7 @@ public class ModifyConflictTest extends ReplicationTestCase
      * sure...)
      */
     testModify(entry, hist, 2, false, newModification(ADD, DESCRIPTION, "older value"));
-    assertEquals(hist.encodeAndPurge(), repl);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), repl);
 
     /*
      * Now simulate an add at a later date that the previous replace.
@@ -114,7 +115,7 @@ public class ModifyConflictTest extends ReplicationTestCase
     Attribute attr = buildSyncHist(DESCRIPTION,
         ":000000000000000a000000000000:repl:init value",
         ":000000000000000b000000000000:add:new value");
-    assertEquals(hist.encodeAndPurge(), attr);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), attr);
   }
 
   /**
@@ -132,14 +133,14 @@ public class ModifyConflictTest extends ReplicationTestCase
 
     // simulate a modify-replace done at time t10
     testModify(entry, hist, 10, true, newModification(REPLACE, DISPLAYNAME, "init value"));
-    assertEquals(hist.encodeAndPurge(), repl);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), repl);
 
     /*
      * Now simulate an add at an earlier date that the previous replace
      * conflict resolution should remove it.
      */
     testModify(entry, hist, 1, false, newModification(ADD, DISPLAYNAME, "older value"));
-    assertEquals(hist.encodeAndPurge(), repl);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), repl);
 
     /*
      * Now simulate an add at an earlier date that the previous replace
@@ -147,14 +148,14 @@ public class ModifyConflictTest extends ReplicationTestCase
      * sure...)
      */
     testModify(entry, hist, 2, false, newModification(ADD, DISPLAYNAME, "older value"));
-    assertEquals(hist.encodeAndPurge(), repl);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), repl);
 
     /*
      * Now simulate an add at a later date that the previous replace.
      * conflict resolution should remove it
      */
     testModify(entry, hist, 11, false, newModification(ADD, DISPLAYNAME, "new value"));
-    assertEquals(hist.encodeAndPurge(), repl);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), repl);
 
     assertContainsOnlyValues(entry, DISPLAYNAME, "init value");
   }
@@ -175,14 +176,14 @@ public class ModifyConflictTest extends ReplicationTestCase
 
     // simulate a replace with null done at time t3
     testModify(entry, hist, 3, true, newModification(REPLACE, DISPLAYNAME));
-    assertEquals(hist.encodeAndPurge(), attrDel);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), attrDel);
 
     /*
      * Now simulate an add at an earlier date that the previous replace. The
      * conflict resolution should detect that this add must be ignored.
      */
     testModify(entry, hist, 1, false, newModification(ADD, DISPLAYNAME, "older value"));
-    assertEquals(hist.encodeAndPurge(), attrDel);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), attrDel);
 
     /*
      * Now simulate an add at an earlier date that the previous delete. The
@@ -190,7 +191,7 @@ public class ModifyConflictTest extends ReplicationTestCase
      * second time to make sure that historical information is kept...)
      */
     testModify(entry, hist, 2, false, newModification(ADD, DISPLAYNAME, "older value"));
-    assertEquals(hist.encodeAndPurge(), attrDel);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), attrDel);
 
     /*
      * Now simulate an add at a later date that the previous delete.
@@ -200,7 +201,7 @@ public class ModifyConflictTest extends ReplicationTestCase
     Attribute attr = buildSyncHist(DISPLAYNAME,
         ":0000000000000004000000000000:add:new value",
         ":0000000000000003000000000000:attrDel");
-    assertEquals(hist.encodeAndPurge(), attr);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), attr);
   }
 
   /**
@@ -217,7 +218,7 @@ public class ModifyConflictTest extends ReplicationTestCase
     testModify(entry, hist, 10, true, newModification(ADD, DESCRIPTION, "init value"));
     Attribute attr = buildSyncHist(DESCRIPTION,
         ":000000000000000a000000000000:add:init value");
-    assertEquals(hist.encodeAndPurge(), attr);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), attr);
 
     /*
      * Now simulate a replace at an earlier date that the previous replace
@@ -227,7 +228,7 @@ public class ModifyConflictTest extends ReplicationTestCase
     attr = buildSyncHist(DESCRIPTION,
         ":000000000000000a000000000000:add:init value",
         ":0000000000000001000000000000:repl:older value");
-    assertEquals(hist.encodeAndPurge(), attr);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), attr);
 
     /*
      * Now simulate a replace at an earlier date that the previous replace
@@ -238,7 +239,7 @@ public class ModifyConflictTest extends ReplicationTestCase
     attr = buildSyncHist(DESCRIPTION,
         ":000000000000000a000000000000:add:init value",
         ":0000000000000002000000000000:repl:older value");
-    assertEquals(hist.encodeAndPurge(), attr);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), attr);
 
     /*
      * Now simulate a replace at a later date that the previous replace.
@@ -247,7 +248,7 @@ public class ModifyConflictTest extends ReplicationTestCase
     testModify(entry, hist, 11, true, newModification(REPLACE, DESCRIPTION, "new value"));
     attr = buildSyncHist(DESCRIPTION,
         ":000000000000000b000000000000:repl:new value");
-    assertEquals(hist.encodeAndPurge(), attr);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), attr);
   }
 
   /**
@@ -264,7 +265,7 @@ public class ModifyConflictTest extends ReplicationTestCase
     testModify(entry, hist, 2, true, newModification(ADD, DISPLAYNAME, "init value"));
     Attribute syncHist = buildSyncHist(DISPLAYNAME,
         ":0000000000000002000000000000:add:init value");
-    assertEquals(hist.encodeAndPurge(), syncHist);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), syncHist);
 
     /*
      * Now simulate a replace at an earlier date that the previous replace
@@ -273,7 +274,7 @@ public class ModifyConflictTest extends ReplicationTestCase
     testModify(entry, hist, 1, true, newModification(REPLACE, DISPLAYNAME, "older value"));
     syncHist = buildSyncHist(DISPLAYNAME,
         ":0000000000000001000000000000:repl:older value");
-    assertEquals(hist.encodeAndPurge(), syncHist);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), syncHist);
 
     assertContainsOnlyValues(entry, DISPLAYNAME, "older value");
 
@@ -284,7 +285,7 @@ public class ModifyConflictTest extends ReplicationTestCase
     testModify(entry, hist, 3, true, newModification(REPLACE, DISPLAYNAME, "newer value"));
     syncHist = buildSyncHist(DISPLAYNAME,
         ":0000000000000003000000000000:repl:newer value");
-    assertEquals(hist.encodeAndPurge(), syncHist);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), syncHist);
 
     assertContainsOnlyValues(entry, DISPLAYNAME, "newer value");
   }
@@ -304,14 +305,14 @@ public class ModifyConflictTest extends ReplicationTestCase
 
     // simulate a delete of the whole description attribute done at time t10
     testModify(entry, hist, 10, true, newModification(DELETE, DESCRIPTION));
-    assertEquals(hist.encodeAndPurge(), attrDel);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), attrDel);
 
     /*
      * Now simulate an add at an earlier date that the previous delete. The
      * conflict resolution should detect that this add must be ignored.
      */
     testModify(entry, hist, 1, false, newModification(ADD, DESCRIPTION, "older value"));
-    assertEquals(hist.encodeAndPurge(), attrDel);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), attrDel);
 
     /*
      * Now simulate an add at an earlier date that the previous delete. The
@@ -319,7 +320,7 @@ public class ModifyConflictTest extends ReplicationTestCase
      * second time to make sure that historical information is kept...)
      */
     testModify(entry, hist, 2, false, newModification(ADD, DESCRIPTION, "older value"));
-    assertEquals(hist.encodeAndPurge(), attrDel);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), attrDel);
 
     /*
      * Now simulate an add at a later date that the previous delete.
@@ -329,7 +330,7 @@ public class ModifyConflictTest extends ReplicationTestCase
     Attribute attr = buildSyncHist(DESCRIPTION,
             ":000000000000000b000000000000:add:new value",
             ":000000000000000a000000000000:attrDel");
-    assertEquals(hist.encodeAndPurge(), attr);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), attr);
   }
 
   /**
@@ -348,21 +349,21 @@ public class ModifyConflictTest extends ReplicationTestCase
     testModify(entry, hist, 1, true, newModification(DELETE, DESCRIPTION, "value1"));
     Attribute attr = buildSyncHist(DESCRIPTION,
         ":0000000000000001000000000000:del:value1");
-    assertEquals(hist.encodeAndPurge(), attr);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), attr);
 
     // Now simulate an add of "value3" at time t2
     testModify(entry, hist, 2, true, newModification(ADD, DESCRIPTION, "value3"));
     attr = buildSyncHist(DESCRIPTION,
         ":0000000000000001000000000000:del:value1",
         ":0000000000000002000000000000:add:value3");
-    assertEquals(hist.encodeAndPurge(), attr);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), attr);
 
     // Now simulate a delete of value "value1" at time t3
     testModify(entry, hist, 3, false, newModification(DELETE, DESCRIPTION, "value1"));
     attr = buildSyncHist(DESCRIPTION,
         ":0000000000000002000000000000:add:value3",
         ":0000000000000003000000000000:del:value1");
-    assertEquals(hist.encodeAndPurge(), attr);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), attr);
 
     // Now simulate an add of "value4" at time t4
     testModify(entry, hist, 4, true, newModification(ADD, DESCRIPTION, "value4"));
@@ -370,7 +371,7 @@ public class ModifyConflictTest extends ReplicationTestCase
         ":0000000000000002000000000000:add:value3",
         ":0000000000000003000000000000:del:value1",
         ":0000000000000004000000000000:add:value4");
-    assertEquals(hist.encodeAndPurge(), attr);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), attr);
   }
 
   /**
@@ -394,7 +395,7 @@ public class ModifyConflictTest extends ReplicationTestCase
     Attribute attr = buildSyncHist(DESCRIPTION,
         ":0000000000000001000000000000:del:value1",
         ":0000000000000001000000000000:del:value2");
-    assertEquals(hist.encodeAndPurge(), attr);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), attr);
 
     /*
      * simulate a delete of the description attribute values
@@ -406,7 +407,7 @@ public class ModifyConflictTest extends ReplicationTestCase
         ":0000000000000001000000000000:del:value1",
         ":0000000000000002000000000000:del:value2",
         ":0000000000000002000000000000:del:value3");
-    assertEquals(hist.encodeAndPurge(), attr);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), attr);
 
     assertContainsOnlyValues(entry, DESCRIPTION, "value1");
   }
@@ -433,13 +434,13 @@ public class ModifyConflictTest extends ReplicationTestCase
     testModify(entry, hist, 1, true, newModification(DELETE, EMPLOYEENUMBER));
     Attribute attr = buildSyncHist(EMPLOYEENUMBER,
         ":0000000000000001000000000000:attrDel");
-    assertEquals(hist.encodeAndPurge(), attr);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), attr);
 
     // now simulate a delete of value "value1"
     testModify(entry, hist, 2, false, newModification(DELETE, EMPLOYEENUMBER, "value1"));
     attr = buildSyncHist(EMPLOYEENUMBER,
         ":0000000000000002000000000000:attrDel");
-    assertEquals(hist.encodeAndPurge(), attr);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), attr);
   }
 
   /**
@@ -458,13 +459,13 @@ public class ModifyConflictTest extends ReplicationTestCase
     testModify(entry, hist, 1, true, newModification(DELETE, EMPLOYEENUMBER, "value1"));
     Attribute attr = buildSyncHist(EMPLOYEENUMBER,
         ":0000000000000001000000000000:attrDel");
-    assertEquals(hist.encodeAndPurge(), attr);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), attr);
 
     // simulate a delete of attribute employeenumber.
     testModify(entry, hist, 2, false, newModification(DELETE, EMPLOYEENUMBER));
     attr = buildSyncHist(EMPLOYEENUMBER,
         ":0000000000000002000000000000:attrDel");
-    assertEquals(hist.encodeAndPurge(), attr);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), attr);
   }
 
   /**
@@ -487,21 +488,21 @@ public class ModifyConflictTest extends ReplicationTestCase
     testModify(entry, hist, 3, true, newModification(DELETE, DESCRIPTION, "value1"));
     Attribute attr = buildSyncHist(DESCRIPTION,
         ":0000000000000003000000000000:del:value1");
-    assertEquals(hist.encodeAndPurge(), attr);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), attr);
 
     // Now simulate an add of "value3" at time t4
     testModify(entry, hist, 4, true, newModification(ADD, DESCRIPTION, "value3"));
     attr = buildSyncHist(DESCRIPTION,
         ":0000000000000003000000000000:del:value1",
         ":0000000000000004000000000000:add:value3");
-    assertEquals(hist.encodeAndPurge(), attr);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), attr);
 
     // Now simulate a delete of value "value1" at time t1
     testModify(entry, hist, 1, false, newModification(DELETE, DESCRIPTION, "value1"));
     attr = buildSyncHist(DESCRIPTION,
         ":0000000000000003000000000000:del:value1",
         ":0000000000000004000000000000:add:value3");
-    assertEquals(hist.encodeAndPurge(), attr);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), attr);
 
     // Now simulate an add of "value4" at time t2
     testModify(entry, hist, 2, true, newModification(ADD, DESCRIPTION, "value4"));
@@ -509,7 +510,7 @@ public class ModifyConflictTest extends ReplicationTestCase
         ":0000000000000003000000000000:del:value1",
         ":0000000000000004000000000000:add:value3",
         ":0000000000000002000000000000:add:value4");
-    assertEquals(hist.encodeAndPurge(), attr);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), attr);
   }
 
   /**
@@ -527,14 +528,14 @@ public class ModifyConflictTest extends ReplicationTestCase
         ":0000000000000003000000000000:attrDel");
     // simulate a delete of the whole description attribute done at time t2
     testModify(entry, hist, 3, true, newModification(DELETE, DISPLAYNAME));
-    assertEquals(hist.encodeAndPurge(), attrDel);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), attrDel);
 
     /*
      * Now simulate an add at an earlier date that the previous delete. The
      * conflict resolution should detect that this add must be ignored.
      */
     testModify(entry, hist, 1, false, newModification(ADD, DISPLAYNAME, "older value"));
-    assertEquals(hist.encodeAndPurge(), attrDel);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), attrDel);
 
     /*
      * Now simulate an add at an earlier date that the previous delete. The
@@ -542,7 +543,7 @@ public class ModifyConflictTest extends ReplicationTestCase
      * second time to make sure that historical information is kept...)
      */
     testModify(entry, hist, 2, false, newModification(ADD, DISPLAYNAME, "older value"));
-    assertEquals(hist.encodeAndPurge(), attrDel);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), attrDel);
 
     /*
      * Now simulate an add at a later date that the previous delete.
@@ -552,7 +553,7 @@ public class ModifyConflictTest extends ReplicationTestCase
     Attribute attr = buildSyncHist(DISPLAYNAME,
         ":0000000000000003000000000000:attrDel",
         ":0000000000000004000000000000:add:new value");
-    assertEquals(hist.encodeAndPurge(), attr);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), attr);
   }
 
   /**
@@ -569,14 +570,14 @@ public class ModifyConflictTest extends ReplicationTestCase
         ":0000000000000004000000000000:attrDel");
     // simulate a delete of the whole description attribute done at time t4
     testModify(entry, hist, 4, true, newModification(DELETE, DESCRIPTION));
-    assertEquals(hist.encodeAndPurge(), attrDel);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), attrDel);
 
     /*
      * Now simulate a replace at an earlier date that the previous delete. The
      * conflict resolution should detect that this replace must be ignored.
      */
     testModify(entry, hist, 3, false, newModification(REPLACE, DESCRIPTION, "new value"));
-    assertEquals(hist.encodeAndPurge(), attrDel);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), attrDel);
   }
 
   /**
@@ -599,14 +600,14 @@ public class ModifyConflictTest extends ReplicationTestCase
         ":0000000000000001000000000000:repl:value1",
         ":0000000000000001000000000000:add:value2",
         ":0000000000000001000000000000:add:value3");
-    assertEquals(hist.encodeAndPurge(), attr);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), attr);
 
     // simulate a DELETE of the attribute values : value3 and value4 at time t2.
     mod = newModification(DELETE, DESCRIPTION, "value3", "value4");
     List<Modification> mods = newArrayList(mod);
     replayModifiesAndAssert(entry, hist, 2, mods);
     assertSame(mod, mods.get(0));
-    assertEquals(mod.getAttribute(), Attributes.create(DESCRIPTION, "value3"));
+    TestCaseUtils.assertObjectEquals(mod.getAttribute(), Attributes.create(DESCRIPTION, "value3"));
     assertEquals(mod.getModificationType(), DELETE);
 
     attr = buildSyncHist(DESCRIPTION,
@@ -614,7 +615,7 @@ public class ModifyConflictTest extends ReplicationTestCase
         ":0000000000000001000000000000:add:value2",
         ":0000000000000002000000000000:del:value3",
         ":0000000000000002000000000000:del:value4");
-    assertEquals(hist.encodeAndPurge(), attr);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), attr);
   }
 
   /**
@@ -644,18 +645,18 @@ public class ModifyConflictTest extends ReplicationTestCase
     // check that the MOD is not altered by the replay mechanism.
     assertSame(mod, mods.get(0));
     assertEquals(mod.getModificationType(), DELETE);
-    assertEquals(mod.getAttribute(), values3and4);
+    TestCaseUtils.assertObjectEquals(mod.getAttribute(), values3and4);
 
     // check that the entry now contains value1 and value2 and no other values.
     Iterable<Attribute> attrs = entry.getAllAttributes(DESCRIPTION);
     assertThat(attrs).hasSize(1);
     Attribute resultEntryAttr = attrs.iterator().next();
-    assertEquals(resultEntryAttr, values1and2);
+    TestCaseUtils.assertObjectEquals(resultEntryAttr, values1and2);
 
     Attribute attr = buildSyncHist(DESCRIPTION,
         ":0000000000000002000000000000:del:value3",
         ":0000000000000002000000000000:del:value4");
-    assertEquals(hist.encodeAndPurge(), attr);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), attr);
 
     // simulate a REPLACE of the attribute with values : value1, value2, value3
     // at time t1.
@@ -667,16 +668,16 @@ public class ModifyConflictTest extends ReplicationTestCase
     // check that value3 has been removed from the MOD-REPLACE because
     // a later operation contains a MOD-DELETE of this value.
     assertEquals(mod.getModificationType(), REPLACE);
-    assertEquals(mod.getAttribute(), values1and2);
+    TestCaseUtils.assertObjectEquals(mod.getAttribute(), values1and2);
     // check that the entry now contains value1 and value2 and no other values.
-    assertEquals(resultEntryAttr, values1and2);
+    TestCaseUtils.assertObjectEquals(resultEntryAttr, values1and2);
 
     attr = buildSyncHist(DESCRIPTION,
         ":0000000000000001000000000000:repl:value1",
         ":0000000000000001000000000000:add:value2",
         ":0000000000000002000000000000:del:value3",
         ":0000000000000002000000000000:del:value4");
-    assertEquals(hist.encodeAndPurge(), attr);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), attr);
   }
 
   /**
@@ -695,14 +696,14 @@ public class ModifyConflictTest extends ReplicationTestCase
 
     // simulate a delete of the whole description attribute done at time t4
     testModify(entry, hist, 4, true, newModification(DELETE, DISPLAYNAME));
-    assertEquals(hist.encodeAndPurge(), attrDel);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), attrDel);
 
     /*
      * Now simulate a replace at an earlier date that the previous delete. The
      * conflict resolution should detect that this replace must be ignored.
      */
     testModify(entry, hist, 3, false, newModification(REPLACE, DISPLAYNAME, "new value"));
-    assertEquals(hist.encodeAndPurge(), attrDel);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), attrDel);
   }
 
   /**
@@ -719,7 +720,7 @@ public class ModifyConflictTest extends ReplicationTestCase
     testModify(entry, hist, 10, true, newModification(ADD, DESCRIPTION, "init value"));
     Attribute attr = buildSyncHist(DESCRIPTION,
         ":000000000000000a000000000000:add:init value");
-    assertEquals(hist.encodeAndPurge(), attr);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), attr);
 
     /*
      * Now simulate an add at an earlier date that the previous add. The
@@ -729,7 +730,7 @@ public class ModifyConflictTest extends ReplicationTestCase
     attr = buildSyncHist(DESCRIPTION,
         ":000000000000000a000000000000:add:init value",
         ":0000000000000001000000000000:add:older value");
-    assertEquals(hist.encodeAndPurge(), attr);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), attr);
 
     /*
      * Now simulate an add with a value already existing.
@@ -739,7 +740,7 @@ public class ModifyConflictTest extends ReplicationTestCase
     attr = buildSyncHist(DESCRIPTION,
         ":0000000000000001000000000000:add:older value",
         ":000000000000000d000000000000:add:init value");
-    assertEquals(hist.encodeAndPurge(), attr);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), attr);
 
     /*
      * Now simulate an add at a later date that the previous add. conflict
@@ -750,7 +751,7 @@ public class ModifyConflictTest extends ReplicationTestCase
         ":0000000000000001000000000000:add:older value",
         ":000000000000000d000000000000:add:init value",
         ":000000000000000e000000000000:add:new value");
-    assertEquals(hist.encodeAndPurge(), attr);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), attr);
   }
 
   /**
@@ -770,7 +771,7 @@ public class ModifyConflictTest extends ReplicationTestCase
     testModify(entry, hist, 10, true, newModification(ADD, DESCRIPTION, "Init Value"));
     Attribute attr = buildSyncHist(DESCRIPTION,
         ":000000000000000a000000000000:add:Init Value");
-    assertEquals(hist.encodeAndPurge(), attr);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), attr);
 
     // Now simulate a del and a add in the same operation
     Modification mod1 = newModification(DELETE, DESCRIPTION, "Init Value");
@@ -781,7 +782,7 @@ public class ModifyConflictTest extends ReplicationTestCase
     assertThat(mods).as("DEL and ADD of the same attribute same value was not correct").containsExactly(mod1, mod2);
     attr = buildSyncHist(DESCRIPTION,
         ":000000000000000b000000000000:add:Init Value");
-    assertEquals(hist.encodeAndPurge(), attr);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), attr);
   }
 
   /**
@@ -805,14 +806,14 @@ public class ModifyConflictTest extends ReplicationTestCase
     testModify(entry, hist, 10, true, newModification(ADD, DESCRIPTION, "init value"));
     Attribute attr = buildSyncHist(DESCRIPTION,
         ":000000000000000a000000000000:add:init value");
-    assertEquals(hist.encodeAndPurge(), attr);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), attr);
 
     // simulate a add of the description attribute done at time t10
     testModify(entry, hist, 11, true, newModification(ADD, DESCRIPTION, "second value"));
     attr = buildSyncHist(DESCRIPTION,
         ":000000000000000a000000000000:add:init value",
         ":000000000000000b000000000000:add:second value");
-    assertEquals(hist.encodeAndPurge(), attr);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), attr);
 
     /*
      * Now simulate a delete of one value and a replace with no value
@@ -825,14 +826,14 @@ public class ModifyConflictTest extends ReplicationTestCase
 
     List<Modification> mods2 = new LinkedList<>(mods);
     replayModifies(entry, hist, 12, mods);
-    assertEquals(hist.encodeAndPurge(), attrDel);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), attrDel);
     assertThat(mods)
       .as("DEL one value, del by Replace of the same attribute was not correct")
       .containsExactly(mod1, mod2);
 
     // Replay the same modifs again
     replayModifies(entry, hist, 12, mods2);
-    assertEquals(hist.encodeAndPurge(), attrDel);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), attrDel);
     assertEquals(mods2.size(), 2,
       "DEL one value, del by Replace of the same attribute was not correct");
   }
@@ -858,7 +859,7 @@ public class ModifyConflictTest extends ReplicationTestCase
     replayModifies(entry, hist, 11, mods);
     Attribute attr = buildSyncHist(DESCRIPTION,
         ":000000000000000b000000000000:del:Init Value");
-    assertEquals(hist.encodeAndPurge(), attr);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), attr);
     assertThat(mods).as("DEL and ADD of the same attribute same value was not correct").containsExactly(mod1, mod2);
   }
 
@@ -880,7 +881,7 @@ public class ModifyConflictTest extends ReplicationTestCase
     testModify(entry, hist, 1, true, newModification(ADD, DESCRIPTION, "value1"));
     Attribute attr = buildSyncHist(DESCRIPTION,
         ":0000000000000001000000000000:add:value1");
-    assertEquals(hist.encodeAndPurge(), attr);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), attr);
 
     /*
      * simulate an add of the description attribute values
@@ -891,7 +892,7 @@ public class ModifyConflictTest extends ReplicationTestCase
     attr = buildSyncHist(DESCRIPTION,
         ":0000000000000002000000000000:add:value1",
         ":0000000000000002000000000000:add:value2");
-    assertEquals(hist.encodeAndPurge(), attr);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), attr);
 
     assertContainsOnlyValues(entry, DESCRIPTION, "value1", "value2");
 
@@ -909,14 +910,14 @@ public class ModifyConflictTest extends ReplicationTestCase
     attr = buildSyncHist(DESCRIPTION,
         ":0000000000000001000000000000:add:value1",
         ":0000000000000001000000000000:add:value2");
-    assertEquals(hist.encodeAndPurge(), attr);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), attr);
 
     // simulate a add of the description attribute done at time 1
     testModify(entry, hist, 2, false, newModification(ADD, DESCRIPTION, "value1"));
     attr = buildSyncHist(DESCRIPTION,
         ":0000000000000001000000000000:add:value2",
         ":0000000000000002000000000000:add:value1");
-    assertEquals(hist.encodeAndPurge(), attr);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), attr);
 
     assertContainsOnlyValues(entry, DESCRIPTION, "value1", "value2");
   }
@@ -938,7 +939,7 @@ public class ModifyConflictTest extends ReplicationTestCase
     testModify(entry, hist, 10, true, newModification(ADD, DISPLAYNAME, "init value"));
     Attribute attr = buildSyncHist(DISPLAYNAME,
         ":000000000000000a000000000000:add:init value");
-    assertEquals(hist.encodeAndPurge(), attr);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), attr);
 
     List<Modification> mods;
     /*
@@ -949,7 +950,7 @@ public class ModifyConflictTest extends ReplicationTestCase
      */
     mods = newArrayList(newModification(ADD, DISPLAYNAME, "older value"));
     replayModifiesAndAssert(entry, hist, 1, mods);
-    assertEquals(hist.encodeAndPurge(), olderValue);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), olderValue);
 
     /*
      * After replay the mods should contain only one mod,
@@ -964,7 +965,7 @@ public class ModifyConflictTest extends ReplicationTestCase
      */
     mods = newArrayList(newModification(ADD, DISPLAYNAME, "new value"));
     replayModifiesAndAssert(entry, hist, 2, mods);
-    assertEquals(hist.encodeAndPurge(), olderValue);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), olderValue);
     assertTrue(mods.isEmpty());
   }
 
@@ -985,14 +986,14 @@ public class ModifyConflictTest extends ReplicationTestCase
     testModify(entry, hist, 1, true, newModification(ADD, DISPLAYNAME, "init value"));
     Attribute attr = buildSyncHist(DISPLAYNAME,
         ":0000000000000001000000000000:add:init value");
-    assertEquals(hist.encodeAndPurge(), attr);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), attr);
 
     /*
      * simulate a del of the displayName attribute done at time t3
      * this should be processed normally
      */
     testModify(entry, hist, 3, true, newModification(DELETE, DISPLAYNAME, "init value"));
-    assertEquals(hist.encodeAndPurge(), attrDel);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), attrDel);
 
     /*
      * Now simulate another add, that would come from another master
@@ -1000,7 +1001,7 @@ public class ModifyConflictTest extends ReplicationTestCase
      * This add should not be processed.
      */
     testModify(entry, hist, 2, false, newModification(ADD, DISPLAYNAME, "second value"));
-    assertEquals(hist.encodeAndPurge(), attrDel);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), attrDel);
   }
 
   /**
@@ -1023,14 +1024,14 @@ public class ModifyConflictTest extends ReplicationTestCase
 
     // simulate a add of the displayName attribute done at time t1
     testModify(entry, hist, 1, true, newModification(ADD, DISPLAYNAME, "first value"));
-    assertEquals(hist.encodeAndPurge(), firstValue);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), firstValue);
 
     /*
      * simulate a add of the displayName attribute done at time t2 with a second value.
      * This should not work because there is already a value
      */
     testModify(entry, hist, 2, false, newModification(ADD, DISPLAYNAME, "second value"));
-    assertEquals(hist.encodeAndPurge(), firstValue);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), firstValue);
 
     /*
      * Now simulate a delete of the second value.
@@ -1038,7 +1039,7 @@ public class ModifyConflictTest extends ReplicationTestCase
      * that did not get into the entry.
      */
     testModify(entry, hist, 2, false, newModification(DELETE, DISPLAYNAME, "second value"));
-    assertEquals(hist.encodeAndPurge(), firstValue);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), firstValue);
   }
 
   /**
@@ -1167,7 +1168,7 @@ public class ModifyConflictTest extends ReplicationTestCase
     entry.removeAttribute(getServerContext().getSchema().getAttributeType(HISTORICAL_ATTRIBUTE_NAME));
     entry.addAttribute(hist.encodeAndPurge(), null);
     EntryHistorical hist2 = EntryHistorical.newInstanceFromEntry(entry);
-    assertEquals(hist2.encodeAndPurge(), hist.encodeAndPurge());
+    TestCaseUtils.assertObjectEquals(hist2.encodeAndPurge(), hist.encodeAndPurge());
   }
 
   private LocalBackendModifyOperation modifyOperation(Entry entry, int date, List<Modification> mods)
@@ -1263,13 +1264,13 @@ public class ModifyConflictTest extends ReplicationTestCase
     testModify(entry, hist, 1, true, newModification(ADD, DISPLAYNAME, "aValue"));
     Attribute attr = buildSyncHist(DISPLAYNAME,
         ":0000000000000001000000000000:add:aValue");
-    assertEquals(hist.encodeAndPurge(), attr);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), attr);
 
     // simulate a delete of the attribute in the same operation done at time t1
     testModify(entry, hist, 1, true, newModification(DELETE, DISPLAYNAME));
     attr = buildSyncHist(DISPLAYNAME,
         ":0000000000000001000000000000:attrDel");
-    assertEquals(hist.encodeAndPurge(), attr);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), attr);
 
     // The entry should have no value
     assertThat(entry.getAllAttributes(DISPLAYNAME)).isEmpty();
@@ -1296,22 +1297,22 @@ public class ModifyConflictTest extends ReplicationTestCase
     testModify(entry, hist, 2, true, newModification(ADD, DISPLAYNAME, "aValue"));
     Attribute attr = buildSyncHist(DISPLAYNAME,
         ":0000000000000002000000000000:add:aValue");
-    assertEquals(hist.encodeAndPurge(), attr);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), attr);
 
     // simulate a delete of the attribute in the same operation done at time t1
     testModify(entry, hist, 2, true, newModification(DELETE, DISPLAYNAME, "aValue"));
-    assertEquals(hist.encodeAndPurge(), attrDel);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), attrDel);
 
     // Redo the same operations. This time, we expect them not to be applied.
     testModify(entry, hist, 2, true, newModification(ADD, DISPLAYNAME, "aValue"));
     attr = buildSyncHist(DISPLAYNAME,
         ":0000000000000002000000000000:add:aValue",
         ":0000000000000002000000000000:attrDel");
-    assertEquals(hist.encodeAndPurge(), attr);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), attr);
 
     // simulate a delete of the attribute in the same operation done at time t1
     testModify(entry, hist, 2, true, newModification(DELETE, DISPLAYNAME, "aValue"));
-    assertEquals(hist.encodeAndPurge(), attrDel);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), attrDel);
 
     // The entry should have no value
     assertThat(entry.getAllAttributes(DISPLAYNAME)).isEmpty();
@@ -1333,21 +1334,21 @@ public class ModifyConflictTest extends ReplicationTestCase
     testModify(entry, hist, 1, true, newModification(DELETE, DESCRIPTION, "value1"));
     attr = buildSyncHist(DESCRIPTION,
         ":0000000000000001000000000000:del:value1");
-    assertEquals(hist.encodeAndPurge(), attr);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), attr);
 
     // simulate an add of new value in the same operation done at time t1
     testModify(entry, hist, 1, true, newModification(ADD, DESCRIPTION, "value3"));
     attr = buildSyncHist(DESCRIPTION,
         ":0000000000000001000000000000:add:value3",
         ":0000000000000001000000000000:del:value1");
-    assertEquals(hist.encodeAndPurge(), attr);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), attr);
 
     // simulate a delete of same value in the same operation done at time t2
     testModify(entry, hist, 2, false, newModification(DELETE, DESCRIPTION, "value1"));
     attr = buildSyncHist(DESCRIPTION,
         ":0000000000000001000000000000:add:value3",
         ":0000000000000002000000000000:del:value1");
-    assertEquals(hist.encodeAndPurge(), attr);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), attr);
 
     // simulate an add of new value in the same operation done at time t2
     testModify(entry, hist, 2, true, newModification(ADD, DESCRIPTION, "value4"));
@@ -1355,7 +1356,7 @@ public class ModifyConflictTest extends ReplicationTestCase
         ":0000000000000001000000000000:add:value3",
         ":0000000000000002000000000000:del:value1",
         ":0000000000000002000000000000:add:value4");
-    assertEquals(hist.encodeAndPurge(), attr);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), attr);
 
     // The entry should have no value
     Iterable<Attribute> attrs = entry.getAllAttributes(DESCRIPTION);
@@ -1378,14 +1379,14 @@ public class ModifyConflictTest extends ReplicationTestCase
     testModify(entry, hist, 1, true, newModification(DELETE, DESCRIPTION, "value1"));
     attr = buildSyncHist(DESCRIPTION,
         ":0000000000000001000000000000:del:value1");
-    assertEquals(hist.encodeAndPurge(), attr);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), attr);
 
     // simulate an add of new value in the same operation done at time t1
     testModify(entry, hist, 1, true, newModification(ADD, DESCRIPTION, "value4"));
     attr = buildSyncHist(DESCRIPTION,
         ":0000000000000001000000000000:add:value4",
         ":0000000000000001000000000000:del:value1");
-    assertEquals(hist.encodeAndPurge(), attr);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), attr);
 
     // simulate a delete of another value in the same operation done at time t2
     testModify(entry, hist, 2, true, newModification(DELETE, DESCRIPTION, "value2"));
@@ -1393,7 +1394,7 @@ public class ModifyConflictTest extends ReplicationTestCase
         ":0000000000000001000000000000:del:value1",
         ":0000000000000001000000000000:add:value4",
         ":0000000000000002000000000000:del:value2");
-    assertEquals(hist.encodeAndPurge(), attr);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), attr);
 
     // simulate an add of already added value in the same operation done at time
     // t2
@@ -1402,7 +1403,7 @@ public class ModifyConflictTest extends ReplicationTestCase
         ":0000000000000001000000000000:del:value1",
         ":0000000000000002000000000000:del:value2",
         ":0000000000000002000000000000:add:value4");
-    assertEquals(hist.encodeAndPurge(), attr);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), attr);
 
     // The entry should have no value
     Iterable<Attribute> attrs = entry.getAllAttributes(DESCRIPTION);
@@ -1430,22 +1431,22 @@ public class ModifyConflictTest extends ReplicationTestCase
     testModify(entry, hist, 1, true, newModification(ADD, DISPLAYNAME, "aValue"));
     Attribute attr = buildSyncHist(DISPLAYNAME,
         ":0000000000000001000000000000:add:aValue");
-    assertEquals(hist.encodeAndPurge(), attr);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), attr);
 
     // simulate a delete of the attribute in the same operation done at time t1
     testModify(entry, hist, 1, true, newModification(DELETE, DISPLAYNAME));
-    assertEquals(hist.encodeAndPurge(), attrDel);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), attrDel);
 
     // Redo the same operations. This time, we expect them not to be applied.
     testModify(entry, hist, 1, true, newModification(ADD, DISPLAYNAME, "aValue"));
     attr = buildSyncHist(DISPLAYNAME,
         ":0000000000000001000000000000:add:aValue",
         ":0000000000000001000000000000:attrDel");
-    assertEquals(hist.encodeAndPurge(), attr);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), attr);
 
     // simulate a delete of the attribute in the same operation done at time t1
     testModify(entry, hist, 1, true, newModification(DELETE, DISPLAYNAME));
-    assertEquals(hist.encodeAndPurge(), attrDel);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), attrDel);
 
     // The entry should have no value
     assertThat(entry.getAllAttributes(DISPLAYNAME)).isEmpty();
@@ -1469,13 +1470,13 @@ public class ModifyConflictTest extends ReplicationTestCase
     testModify(entry, hist, 1, true, newModification(REPLACE, DISPLAYNAME, "aValue"));
     Attribute attr = buildSyncHist(DISPLAYNAME,
         ":0000000000000001000000000000:repl:aValue");
-    assertEquals(hist.encodeAndPurge(), attr);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), attr);
 
     // simulate a delete of same value in the same operation done at time t1
     testModify(entry, hist, 1, true, newModification(DELETE, DISPLAYNAME, "aValue"));
     attr = buildSyncHist(DISPLAYNAME,
         ":0000000000000001000000000000:attrDel");
-    assertEquals(hist.encodeAndPurge(), attr);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), attr);
 
     // The entry should have no value
     assertThat(entry.getAllAttributes(DISPLAYNAME)).isEmpty();
@@ -1499,13 +1500,13 @@ public class ModifyConflictTest extends ReplicationTestCase
     testModify(entry, hist, 1, true, newModification(REPLACE, DISPLAYNAME, "aValue"));
     Attribute attr = buildSyncHist(DISPLAYNAME,
         ":0000000000000001000000000000:repl:aValue");
-    assertEquals(hist.encodeAndPurge(), attr);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), attr);
 
     // simulate a delete of the attribute in the same operation done at time t1
     testModify(entry, hist, 1, true, newModification(DELETE, DISPLAYNAME));
     attr = buildSyncHist(DISPLAYNAME,
         ":0000000000000001000000000000:attrDel");
-    assertEquals(hist.encodeAndPurge(), attr);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), attr);
 
     // The entry should have no value
     assertThat(entry.getAllAttributes(DISPLAYNAME)).isEmpty();
@@ -1532,19 +1533,19 @@ public class ModifyConflictTest extends ReplicationTestCase
      * conflict resolution should detect that this add must be ignored.
      */
     testModify(entry, hist, 2, true, newModification(REPLACE, DISPLAYNAME, "aValue"));
-    assertEquals(hist.encodeAndPurge(), repl);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), repl);
 
     // simulate a delete of the attribute in the same operation done at time t1
     testModify(entry, hist, 2, true, newModification(DELETE, DISPLAYNAME, "aValue"));
-    assertEquals(hist.encodeAndPurge(), attrDel);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), attrDel);
 
     // Redo the same operations. This time, we expect them not to be applied.
     testModify(entry, hist, 2, true, newModification(REPLACE, DISPLAYNAME, "aValue"));
-    assertEquals(hist.encodeAndPurge(), repl);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), repl);
 
     // simulate a delete of the attribute in the same operation done at time t1
     testModify(entry, hist, 2, true, newModification(DELETE, DISPLAYNAME, "aValue"));
-    assertEquals(hist.encodeAndPurge(), attrDel);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), attrDel);
 
     // The entry should have no value
     assertThat(entry.getAllAttributes(DISPLAYNAME)).isEmpty();
@@ -1571,19 +1572,19 @@ public class ModifyConflictTest extends ReplicationTestCase
      * conflict resolution should detect that this add must be ignored.
      */
     testModify(entry, hist, 1, true, newModification(REPLACE, DISPLAYNAME, "aValue"));
-    assertEquals(hist.encodeAndPurge(), repl);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), repl);
 
     // simulate a delete of the attribute in the same operation done at time t1
     testModify(entry, hist, 1, true, newModification(DELETE, DISPLAYNAME));
-    assertEquals(hist.encodeAndPurge(), attrDel);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), attrDel);
 
     // Redo the same operations. This time, we expect them not to be applied.
     testModify(entry, hist, 1, true, newModification(REPLACE, DISPLAYNAME, "aValue"));
-    assertEquals(hist.encodeAndPurge(), repl);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), repl);
 
     // simulate a delete of the attribute in the same operation done at time t1
     testModify(entry, hist, 1, true, newModification(DELETE, DISPLAYNAME));
-    assertEquals(hist.encodeAndPurge(), attrDel);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), attrDel);
 
     // The entry should have no value
     assertThat(entry.getAllAttributes(DISPLAYNAME)).isEmpty();
@@ -1607,20 +1608,20 @@ public class ModifyConflictTest extends ReplicationTestCase
     testModify(entry, hist, 1, true, newModification(REPLACE, DISPLAYNAME, "aValue"));
     Attribute syncHist = buildSyncHist(DISPLAYNAME,
         ":0000000000000001000000000000:repl:aValue");
-    assertEquals(hist.encodeAndPurge(), syncHist);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), syncHist);
 
     // simulate a delete of same value in the same operation done at time t1
     testModify(entry, hist, 1, true, newModification(DELETE, DISPLAYNAME, "aValue"));
     syncHist = buildSyncHist(DISPLAYNAME,
         ":0000000000000001000000000000:attrDel");
-    assertEquals(hist.encodeAndPurge(), syncHist);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), syncHist);
 
     // simulate an add of new value in the same operation done at time t1
     testModify(entry, hist, 1, true, newModification(ADD, DISPLAYNAME, "NewValue"));
     syncHist = buildSyncHist(DISPLAYNAME,
         ":0000000000000001000000000000:add:NewValue",
         ":0000000000000001000000000000:attrDel");
-    assertEquals(hist.encodeAndPurge(), syncHist);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), syncHist);
 
     assertContainsOnlyValues(entry, DISPLAYNAME, "NewValue");
   }
@@ -1643,20 +1644,20 @@ public class ModifyConflictTest extends ReplicationTestCase
     testModify(entry, hist, 1, true, newModification(REPLACE, DISPLAYNAME, "aValue"));
     Attribute attr = buildSyncHist(DISPLAYNAME,
         ":0000000000000001000000000000:repl:aValue");
-    assertEquals(hist.encodeAndPurge(), attr);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), attr);
 
     // simulate a delete of same value in the same operation done at time t1
     testModify(entry, hist, 1, true, newModification(DELETE, DISPLAYNAME));
     attr = buildSyncHist(DISPLAYNAME,
         ":0000000000000001000000000000:attrDel");
-    assertEquals(hist.encodeAndPurge(), attr);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), attr);
 
     // simulate an add of new value in the same operation done at time t1
     testModify(entry, hist, 1, true, newModification(ADD, DISPLAYNAME, "NewValue"));
     attr = buildSyncHist(DISPLAYNAME,
         ":0000000000000001000000000000:add:NewValue",
         ":0000000000000001000000000000:attrDel");
-    assertEquals(hist.encodeAndPurge(), attr);
+    TestCaseUtils.assertObjectEquals(hist.encodeAndPurge(), attr);
 
     assertContainsOnlyValues(entry, DISPLAYNAME, "NewValue");
   }

--- a/opendj-server-legacy/src/test/java/org/opends/server/replication/plugin/ModifyReplaySingleValuedAttributeTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/replication/plugin/ModifyReplaySingleValuedAttributeTest.java
@@ -369,7 +369,7 @@ public class ModifyReplaySingleValuedAttributeTest extends ReplicationTestCase
     entry.applyModification(new Modification(REPLACE, entryHistorical.encodeAndPurge()));
 
     Attribute actual = entry.getAttribute(expectedDsSyncHist.getAttributeDescription());
-    Assert.assertEquals(actual, expectedDsSyncHist, "wrong final value for ds-sync-hist attribute");
+    TestCaseUtils.assertObjectEquals(actual, expectedDsSyncHist, "wrong final value for ds-sync-hist attribute");
   }
 
   private void noValue() throws Exception
@@ -405,7 +405,7 @@ public class ModifyReplaySingleValuedAttributeTest extends ReplicationTestCase
     }
 
     Attribute actual = entry.getAttribute(expectedDsSyncHist.getAttributeDescription());
-    Assert.assertEquals(actual, expectedDsSyncHist, "wrong final value for ds-sync-hist attribute");
+    TestCaseUtils.assertObjectEquals(actual, expectedDsSyncHist, "wrong final value for ds-sync-hist attribute");
   }
 
   private static Object[] mods(Mod... mods)

--- a/opendj-server-legacy/src/test/java/org/opends/server/replication/protocol/ByteArrayTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/replication/protocol/ByteArrayTest.java
@@ -23,6 +23,7 @@ import java.util.zip.DataFormatException;
 
 import org.forgerock.opendj.ldap.DN;
 import org.opends.server.DirectoryServerTestCase;
+import org.opends.server.TestCaseUtils;
 import org.opends.server.replication.common.CSN;
 import org.opends.server.replication.common.ServerState;
 import org.testng.annotations.DataProvider;
@@ -115,7 +116,7 @@ public class ByteArrayTest extends DirectoryServerTestCase
     assertEquals(scanner.nextLongUTF8(), l);
     assertEquals(scanner.nextCSN(), csn);
     assertEquals(scanner.nextCSNUTF8(), csn);
-    assertEquals(scanner.nextDN(), dn);
+    TestCaseUtils.assertObjectEquals(scanner.nextDN(), dn);
     assertEquals(scanner.nextByteArray(byteArray.length), byteArray);
     scanner.skipZeroSeparator();
     assertEquals(scanner.nextByteArray(byteArray.length), byteArray);

--- a/opendj-server-legacy/src/test/java/org/opends/server/replication/protocol/ProtocolCompatibilityTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/replication/protocol/ProtocolCompatibilityTest.java
@@ -43,6 +43,7 @@ import org.assertj.core.api.Assertions;
 import org.forgerock.i18n.LocalizableMessage;
 import org.forgerock.opendj.ldap.DN;
 import org.forgerock.opendj.ldap.schema.AttributeType;
+import org.opends.server.TestCaseUtils;
 import org.opends.server.core.AddOperationBasis;
 import org.opends.server.core.DirectoryServer;
 import org.opends.server.core.ModifyDNOperationBasis;
@@ -141,7 +142,7 @@ public class ProtocolCompatibilityTest extends ReplicationTestCase {
     assertEquals(msg.getGenerationId(), newMsg.getGenerationId());
     assertEquals(msg.getServerId(), newMsg.getServerId());
     assertEquals(msg.getServerURL(), newMsg.getServerURL());
-    assertEquals(msg.getBaseDN(), newMsg.getBaseDN());
+    TestCaseUtils.assertObjectEquals(msg.getBaseDN(), newMsg.getBaseDN());
     assertEquals(msg.getWindowSize(), newMsg.getWindowSize());
     assertEquals(msg.getServerState().getCSN(1), newMsg.getServerState().getCSN(1));
     assertEquals(msg.getSSLEncryption(), newMsg.getSSLEncryption());
@@ -164,7 +165,7 @@ public class ProtocolCompatibilityTest extends ReplicationTestCase {
     assertEquals(msg.getGenerationId(), vlastMsg.getGenerationId());
     assertEquals(msg.getServerId(), vlastMsg.getServerId());
     assertEquals(msg.getServerURL(), vlastMsg.getServerURL());
-    assertEquals(msg.getBaseDN(), vlastMsg.getBaseDN());
+    TestCaseUtils.assertObjectEquals(msg.getBaseDN(), vlastMsg.getBaseDN());
     assertEquals(msg.getWindowSize(), vlastMsg.getWindowSize());
     assertEquals(msg.getServerState().getCSN(1), vlastMsg.getServerState().getCSN(1));
     assertEquals(msg.getSSLEncryption(), vlastMsg.getSSLEncryption());
@@ -236,7 +237,7 @@ public class ProtocolCompatibilityTest extends ReplicationTestCase {
 
     // Check fields common to both versions
     assertEquals(newMsg.getEntryUUID(), msg.getEntryUUID());
-    assertEquals(newMsg.getDN(), msg.getDN());
+    TestCaseUtils.assertObjectEquals(newMsg.getDN(), msg.getDN());
     assertEquals(newMsg.getCSN(), msg.getCSN());
     assertEquals(newMsg.isAssured(), msg.isAssured());
     assertEquals(newMsg.getParentEntryUUID(), msg.getParentEntryUUID());
@@ -279,7 +280,7 @@ public class ProtocolCompatibilityTest extends ReplicationTestCase {
 
     // Check we retrieve original VLAST message (VLAST fields)
     assertEquals(msg.getEntryUUID(), vlastMsg.getEntryUUID());
-    assertEquals(msg.getDN(), vlastMsg.getDN());
+    TestCaseUtils.assertObjectEquals(msg.getDN(), vlastMsg.getDN());
     assertEquals(msg.getCSN(), vlastMsg.getCSN());
     assertEquals(msg.getParentEntryUUID(), vlastMsg.getParentEntryUUID());
     assertEquals(msg.isAssured(), vlastMsg.isAssured());
@@ -394,7 +395,7 @@ public class ProtocolCompatibilityTest extends ReplicationTestCase {
 
     // Check fields common to both versions
     assertEquals(newMsg.getEntryUUID(), msg.getEntryUUID());
-    assertEquals(newMsg.getDN(), msg.getDN());
+    TestCaseUtils.assertObjectEquals(newMsg.getDN(), msg.getDN());
     assertEquals(newMsg.getCSN(), msg.getCSN());
     assertEquals(newMsg.isAssured(), msg.isAssured());
 
@@ -421,7 +422,7 @@ public class ProtocolCompatibilityTest extends ReplicationTestCase {
 
     // Check we retrieve original VLAST message (VLAST fields)
     assertEquals(msg.getEntryUUID(), vlastMsg.getEntryUUID());
-    assertEquals(msg.getDN(), vlastMsg.getDN());
+    TestCaseUtils.assertObjectEquals(msg.getDN(), vlastMsg.getDN());
     assertEquals(msg.getCSN(), vlastMsg.getCSN());
     assertEquals(msg.isAssured(), vlastMsg.isAssured());
     assertEquals(msg.getAssuredMode(), vlastMsg.getAssuredMode());
@@ -537,7 +538,7 @@ public class ProtocolCompatibilityTest extends ReplicationTestCase {
 
     // Check fields common to both versions
     assertEquals(newv1Msg.getEntryUUID(), origVlastMsg.getEntryUUID());
-    assertEquals(newv1Msg.getDN(), origVlastMsg.getDN());
+    TestCaseUtils.assertObjectEquals(newv1Msg.getDN(), origVlastMsg.getDN());
     assertEquals(newv1Msg.getCSN(), origVlastMsg.getCSN());
     assertEquals(newv1Msg.isAssured(), origVlastMsg.isAssured());
 
@@ -580,7 +581,7 @@ public class ProtocolCompatibilityTest extends ReplicationTestCase {
 
     // Check we retrieve original VLAST message (VLAST fields)
     assertEquals(origVlastMsg.getEntryUUID(), generatedVlastMsg.getEntryUUID());
-    assertEquals(origVlastMsg.getDN(), generatedVlastMsg.getDN());
+    TestCaseUtils.assertObjectEquals(origVlastMsg.getDN(), generatedVlastMsg.getDN());
     assertEquals(origVlastMsg.getCSN(), generatedVlastMsg.getCSN());
     assertEquals(origVlastMsg.isAssured(), generatedVlastMsg.isAssured());
     assertEquals(origVlastMsg.getAssuredMode(), generatedVlastMsg.getAssuredMode());
@@ -707,7 +708,7 @@ public class ProtocolCompatibilityTest extends ReplicationTestCase {
 
     // Check fields common to both versions
     assertEquals(newMsg.getEntryUUID(), msg.getEntryUUID());
-    assertEquals(newMsg.getDN(), msg.getDN());
+    TestCaseUtils.assertObjectEquals(newMsg.getDN(), msg.getDN());
     assertEquals(newMsg.getCSN(), msg.getCSN());
     assertEquals(newMsg.isAssured(), msg.isAssured());
     assertEquals(newMsg.getNewRDN(), msg.getNewRDN());
@@ -753,7 +754,7 @@ public class ProtocolCompatibilityTest extends ReplicationTestCase {
 
     // Check we retrieve original VLAST message (VLAST fields)
     assertEquals(msg.getEntryUUID(), vlastMsg.getEntryUUID());
-    assertEquals(msg.getDN(), vlastMsg.getDN());
+    TestCaseUtils.assertObjectEquals(msg.getDN(), vlastMsg.getDN());
     assertEquals(msg.getCSN(), vlastMsg.getCSN());
     assertEquals(msg.isAssured(), vlastMsg.isAssured());
     assertEquals(msg.getAssuredMode(), vlastMsg.getAssuredMode());
@@ -841,7 +842,7 @@ public class ProtocolCompatibilityTest extends ReplicationTestCase {
   {
     LDAPUpdateMsg msg = (LDAPUpdateMsg) ReplicationMsg.generateMsg(
         hexStringToByteArray(encodedString), ProtocolVersion.REPLICATION_PROTOCOL_V3);
-    assertEquals(msg.getDN(), DN.valueOf(dn));
+    TestCaseUtils.assertObjectEquals(msg.getDN(), DN.valueOf(dn));
     assertEquals(msg.getCSN(), csn);
     assertEquals(msg.getClass(), msgType);
     BigInteger bi = new BigInteger(msg.getBytes(ProtocolVersion.REPLICATION_PROTOCOL_V3));
@@ -868,7 +869,7 @@ public class ProtocolCompatibilityTest extends ReplicationTestCase {
     // parameters
     ServerStartMsg msg = new ServerStartMsg(hexStringToByteArray(oldPdu));
     assertEquals(msg.getServerId(), serverId);
-    assertEquals(msg.getBaseDN(), DN.valueOf(dn));
+    TestCaseUtils.assertObjectEquals(msg.getBaseDN(), DN.valueOf(dn));
     assertEquals(msg.getGroupId(), groupId);
     BigInteger bi = new BigInteger(msg.getBytes(getCurrentVersion()));
     assertEquals(bi.toString(16), oldPdu);
@@ -894,7 +895,7 @@ public class ProtocolCompatibilityTest extends ReplicationTestCase {
     // parameters.
     ReplServerStartMsg msg = new ReplServerStartMsg(hexStringToByteArray(oldPdu));
     assertEquals(msg.getServerId(), serverId);
-    assertEquals(msg.getBaseDN(), DN.valueOf(dn));
+    TestCaseUtils.assertObjectEquals(msg.getBaseDN(), DN.valueOf(dn));
     assertEquals(msg.getGroupId(), groupId);
     BigInteger bi = new BigInteger(msg.getBytes(ProtocolVersion.REPLICATION_PROTOCOL_V3));
     assertEquals(bi.toString(16), oldPdu);
@@ -1165,7 +1166,7 @@ public class ProtocolCompatibilityTest extends ReplicationTestCase {
     // Check fields common to both versions
     assertEquals(msg.getSenderID(), newMsg.getSenderID());
     assertEquals(msg.getDestination(), newMsg.getDestination());
-    assertEquals(msg.getBaseDN(), newMsg.getBaseDN());
+    TestCaseUtils.assertObjectEquals(msg.getBaseDN(), newMsg.getBaseDN());
 
     // Check default value for only post V3 fields
     assertEquals(newMsg.getInitWindow(), 0);
@@ -1180,7 +1181,7 @@ public class ProtocolCompatibilityTest extends ReplicationTestCase {
     // Check we retrieve original VLAST message (VLAST fields)
     assertEquals(msg.getSenderID(), vlastMsg.getSenderID());
     assertEquals(msg.getDestination(), vlastMsg.getDestination());
-    assertEquals(msg.getBaseDN(), vlastMsg.getBaseDN());
+    TestCaseUtils.assertObjectEquals(msg.getBaseDN(), vlastMsg.getBaseDN());
     assertEquals(msg.getInitWindow(), vlastMsg.getInitWindow());
   }
 
@@ -1221,7 +1222,7 @@ public class ProtocolCompatibilityTest extends ReplicationTestCase {
     // Check fields common to both versions
     assertEquals(msg.getSenderID(), newMsg.getSenderID());
     assertEquals(msg.getDestination(), newMsg.getDestination());
-    assertEquals(msg.getBaseDN(), newMsg.getBaseDN());
+    TestCaseUtils.assertObjectEquals(msg.getBaseDN(), newMsg.getBaseDN());
     assertEquals(msg.getEntryCount(), newMsg.getEntryCount());
     assertEquals(msg.getInitiatorID(), newMsg.getInitiatorID());
 
@@ -1238,7 +1239,7 @@ public class ProtocolCompatibilityTest extends ReplicationTestCase {
     // Check we retrieve original VLAST message (VLAST fields)
     assertEquals(msg.getSenderID(), vlastMsg.getSenderID());
     assertEquals(msg.getDestination(), vlastMsg.getDestination());
-    assertEquals(msg.getBaseDN(), vlastMsg.getBaseDN());
+    TestCaseUtils.assertObjectEquals(msg.getBaseDN(), vlastMsg.getBaseDN());
     assertEquals(msg.getEntryCount(), vlastMsg.getEntryCount());
     assertEquals(msg.getInitiatorID(), vlastMsg.getInitiatorID());
     assertEquals(msg.getInitWindow(), vlastMsg.getInitWindow());

--- a/opendj-server-legacy/src/test/java/org/opends/server/replication/protocol/SynchronizationMsgTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/replication/protocol/SynchronizationMsgTest.java
@@ -42,6 +42,7 @@ import org.forgerock.opendj.ldap.DN;
 import org.forgerock.opendj.ldap.requests.ModifyDNRequest;
 import org.forgerock.opendj.ldap.schema.AttributeType;
 import org.forgerock.opendj.ldap.schema.ObjectClass;
+import org.opends.server.TestCaseUtils;
 import org.opends.server.controls.SubtreeDeleteControl;
 import org.opends.server.core.AddOperation;
 import org.opends.server.core.AddOperationBasis;
@@ -243,11 +244,11 @@ public class SynchronizationMsgTest extends ReplicationTestCase
     assertEquals(msg.compareTo(generatedMsg), 0);
 
     // Check Get / Set DN
-    assertEquals(msg.getDN(), generatedMsg.getDN());
+    TestCaseUtils.assertObjectEquals(msg.getDN(), generatedMsg.getDN());
 
     DN fakeDN = DN.valueOf("cn=fake cn");
     msg.setDN(fakeDN) ;
-    assertEquals(msg.getDN(), fakeDN) ;
+    TestCaseUtils.assertObjectEquals(msg.getDN(), fakeDN) ;
 
     // Check uuid
     assertEquals(msg.getEntryUUID(), generatedMsg.getEntryUUID());
@@ -670,7 +671,7 @@ public class SynchronizationMsgTest extends ReplicationTestCase
     ServerStartMsg newMsg = new ServerStartMsg(msg.getBytes(getCurrentVersion()));
     assertEquals(msg.getServerId(), newMsg.getServerId());
     assertEquals(msg.getServerURL(), newMsg.getServerURL());
-    assertEquals(msg.getBaseDN(), newMsg.getBaseDN());
+    TestCaseUtils.assertObjectEquals(msg.getBaseDN(), newMsg.getBaseDN());
     assertEquals(msg.getWindowSize(), newMsg.getWindowSize());
     assertEquals(msg.getHeartbeatInterval(), newMsg.getHeartbeatInterval());
     assertEquals(msg.getSSLEncryption(), newMsg.getSSLEncryption());
@@ -714,7 +715,7 @@ public class SynchronizationMsgTest extends ReplicationTestCase
     ReplServerStartMsg newMsg = new ReplServerStartMsg(msg.getBytes(getCurrentVersion()));
     assertEquals(msg.getServerId(), newMsg.getServerId());
     assertEquals(msg.getServerURL(), newMsg.getServerURL());
-    assertEquals(msg.getBaseDN(), newMsg.getBaseDN());
+    TestCaseUtils.assertObjectEquals(msg.getBaseDN(), newMsg.getBaseDN());
     assertEquals(msg.getWindowSize(), newMsg.getWindowSize());
     assertEquals(msg.getServerState().getCSN(1),
         newMsg.getServerState().getCSN(1));
@@ -1023,7 +1024,7 @@ public class SynchronizationMsgTest extends ReplicationTestCase
     byte[] b = msg.getBytes(getCurrentVersion());
     MonitorMsg newMsg = new MonitorMsg(b, getCurrentVersion());
 
-    assertEquals(rsState, msg.getReplServerDbState());
+    TestCaseUtils.assertObjectEquals(rsState, msg.getReplServerDbState());
     assertEquals(newMsg.getReplServerDbState().toString(),
         msg.getReplServerDbState().toString());
 
@@ -1103,7 +1104,7 @@ public class SynchronizationMsgTest extends ReplicationTestCase
     InitializeRequestMsg newMsg = new InitializeRequestMsg(msg.getBytes(getCurrentVersion()),getCurrentVersion());
     assertEquals(msg.getSenderID(), newMsg.getSenderID());
     assertEquals(msg.getDestination(), newMsg.getDestination());
-    assertEquals(msg.getBaseDN(), newMsg.getBaseDN());
+    TestCaseUtils.assertObjectEquals(msg.getBaseDN(), newMsg.getBaseDN());
   }
 
   /**
@@ -1125,13 +1126,13 @@ public class SynchronizationMsgTest extends ReplicationTestCase
     assertEquals(msg.getDestination(), newMsg.getDestination());
     assertEquals(msg.getInitiatorID(), newMsg.getInitiatorID());
     assertEquals(msg.getEntryCount(), newMsg.getEntryCount());
-    assertEquals(msg.getBaseDN(), newMsg.getBaseDN());
+    TestCaseUtils.assertObjectEquals(msg.getBaseDN(), newMsg.getBaseDN());
 
     assertEquals(senderID, newMsg.getSenderID());
     assertEquals(targetID, newMsg.getDestination());
     assertEquals(requestorID, newMsg.getInitiatorID());
     assertEquals(entryCount, newMsg.getEntryCount());
-    assertEquals(TEST_ROOT_DN, newMsg.getBaseDN());
+    TestCaseUtils.assertObjectEquals(TEST_ROOT_DN, newMsg.getBaseDN());
   }
 
   /**

--- a/opendj-server-legacy/src/test/java/org/opends/server/replication/server/changelog/file/FileChangeNumberIndexDBTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/replication/server/changelog/file/FileChangeNumberIndexDBTest.java
@@ -222,7 +222,7 @@ public class FileChangeNumberIndexDBTest extends ReplicationTestCase
     final ChangeNumberIndexRecord newest = cnIndexDB.getNewestRecord();
     assertEquals(oldest.getChangeNumber(), newestChangeNumber);
     assertEquals(oldest.getChangeNumber(), newest.getChangeNumber());
-    assertEquals(oldest.getBaseDN(), newest.getBaseDN());
+    TestCaseUtils.assertObjectEquals(oldest.getBaseDN(), newest.getBaseDN());
     assertEquals(oldest.getCSN(), newest.getCSN());
   }
 

--- a/opendj-server-legacy/src/test/java/org/opends/server/tools/makeldif/MakeLDIFTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/tools/makeldif/MakeLDIFTestCase.java
@@ -321,7 +321,7 @@ public class MakeLDIFTestCase extends ToolsTestCase
     assertThat(attrs).isNotEmpty();
     Attribute a = attrs.iterator().next();
     Attribute expectedRes = Attributes.create(attrName, expectedValue);
-    assertEquals(a, expectedRes);
+    TestCaseUtils.assertObjectEquals(a, expectedRes);
   }
 
   private Entry readEntry(String outLdifFilePath) throws IOException, LDIFException

--- a/opendj-server-legacy/src/test/java/org/opends/server/types/AttributesTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/types/AttributesTest.java
@@ -180,7 +180,7 @@ public class AttributesTest extends TypesTestCase
       Attribute d) throws Exception
   {
     Attribute actual = Attributes.merge(a1, a2);
-    Assert.assertEquals(actual, e);
+    TestCaseUtils.assertObjectEquals(actual, e);
   }
 
 
@@ -209,7 +209,7 @@ public class AttributesTest extends TypesTestCase
   {
     List<ByteString> duplicates = new LinkedList<>();
     Attribute actual = Attributes.merge(a1, a2, duplicates);
-    Assert.assertEquals(actual, e);
+    TestCaseUtils.assertObjectEquals(actual, e);
 
     Assert.assertEquals(duplicates.size(), d.size());
     Assert.assertTrue(d.containsAll(duplicates));
@@ -238,7 +238,7 @@ public class AttributesTest extends TypesTestCase
       Attribute e, Attribute m) throws Exception
   {
     Attribute actual = Attributes.subtract(a1, a2);
-    Assert.assertEquals(actual, e);
+    TestCaseUtils.assertObjectEquals(actual, e);
   }
 
 
@@ -267,7 +267,7 @@ public class AttributesTest extends TypesTestCase
   {
     List<ByteString> missingValues = new LinkedList<>();
     Attribute actual = Attributes.subtract(a1, a2, missingValues);
-    Assert.assertEquals(actual, e);
+    TestCaseUtils.assertObjectEquals(actual, e);
 
     Assert.assertEquals(missingValues.size(), m.size());
     Assert.assertTrue(m.containsAll(missingValues));

--- a/opendj-server-legacy/src/test/java/org/opends/server/types/PrivilegeTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/types/PrivilegeTestCase.java
@@ -26,7 +26,6 @@ import static org.forgerock.opendj.ldap.ResultCode.SUCCESS;
 import static org.forgerock.opendj.ldap.ResultCode.UNWILLING_TO_PERFORM;
 import static org.forgerock.opendj.ldap.requests.Requests.newModifyDNRequest;
 import static org.forgerock.opendj.ldap.requests.Requests.newModifyRequest;
-import static org.opends.server.TestCaseUtils.assertNotEquals;
 import static org.opends.server.protocols.internal.InternalClientConnection.getRootConnection;
 import static org.opends.server.protocols.internal.InternalClientConnection.nextMessageID;
 import static org.opends.server.protocols.internal.InternalClientConnection.nextOperationID;
@@ -38,6 +37,7 @@ import static org.opends.server.types.Privilege.UPDATE_SCHEMA;
 import static org.opends.server.util.CollectionUtils.newArrayList;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 

--- a/opendj-server-legacy/src/test/java/org/opends/server/types/TestDN.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/types/TestDN.java
@@ -63,7 +63,7 @@ public class TestDN extends TypesTestCase {
 
     DN childDN = namingContext.child(RDN.valueOf("ou=People"));
     assertNotNull(backendConfigManager.getParentDNInSuffix(childDN));
-    assertEquals(backendConfigManager.getParentDNInSuffix(childDN), namingContext);
+    TestCaseUtils.assertObjectEquals(backendConfigManager.getParentDNInSuffix(childDN), namingContext);
   }
 }
 

--- a/opendj-server-legacy/src/test/java/org/opends/server/types/TestEntry.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/types/TestEntry.java
@@ -715,8 +715,8 @@ public final class TestEntry extends TypesTestCase {
          "modifyTimestamp: 20070101000001Z");
 
     List<String> expectedAttrNames = newArrayList(
-        "cn", "cn;lang-en-US", "sn", "sn;lang-en-US", "givenName", "givenName;lang-en-US", "creatorsName",
-        "createTimestamp", "modifyTimestamp", "modifiersName");
+        "cn", "cn;lang-en-US", "givenName", "givenName;lang-en-US", "sn", "sn;lang-en-US", "creatorsName",
+        "createTimestamp", "modifiersName", "modifyTimestamp");
 
     Iterator<Attribute> allAttrsIt = e.getAllAttributes().iterator();
     Iterator<String> expectedAttrNameIt = expectedAttrNames.iterator();

--- a/opendj-server-legacy/src/test/java/org/opends/server/util/TestAddChangeRecordEntry.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/util/TestAddChangeRecordEntry.java
@@ -87,7 +87,7 @@ public final class TestAddChangeRecordEntry extends UtilTestCase {
     AddChangeRecordEntry entry = new AddChangeRecordEntry(DN.rootDN(),
         attributes);
 
-    Assert.assertEquals(entry.getDN(), DN.rootDN());
+    TestCaseUtils.assertObjectEquals(entry.getDN(), DN.rootDN());
   }
 
   /**
@@ -104,7 +104,7 @@ public final class TestAddChangeRecordEntry extends UtilTestCase {
     AddChangeRecordEntry entry = new AddChangeRecordEntry(testDN1,
         attributes);
 
-    Assert.assertEquals(entry.getDN(), testDN2);
+    TestCaseUtils.assertObjectEquals(entry.getDN(), testDN2);
   }
 
   /**
@@ -150,6 +150,6 @@ public final class TestAddChangeRecordEntry extends UtilTestCase {
     Assert.assertEquals(attrs.size(), 1);
 
     Attribute first = attrs.get(0);
-    Assert.assertEquals(first, attribute);
+    TestCaseUtils.assertObjectEquals(first, attribute);
   }
 }

--- a/opendj-server-legacy/src/test/java/org/opends/server/util/TestChangeRecordEntry.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/util/TestChangeRecordEntry.java
@@ -97,7 +97,7 @@ public final class TestChangeRecordEntry extends UtilTestCase {
   public void testConstructorEmptyDN() throws Exception {
     MyChangeRecordEntry entry = new MyChangeRecordEntry(DN.rootDN());
 
-    Assert.assertEquals(entry.getDN(), DN.rootDN());
+    TestCaseUtils.assertObjectEquals(entry.getDN(), DN.rootDN());
   }
 
   /**
@@ -113,6 +113,6 @@ public final class TestChangeRecordEntry extends UtilTestCase {
 
     MyChangeRecordEntry entry = new MyChangeRecordEntry(testDN1);
 
-    Assert.assertEquals(entry.getDN(), testDN2);
+    TestCaseUtils.assertObjectEquals(entry.getDN(), testDN2);
   }
 }

--- a/opendj-server-legacy/src/test/java/org/opends/server/util/TestDeleteChangeRecordEntry.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/util/TestDeleteChangeRecordEntry.java
@@ -66,7 +66,7 @@ public final class TestDeleteChangeRecordEntry extends UtilTestCase {
   public void testConstructorEmptyDN() throws Exception {
     DeleteChangeRecordEntry entry = new DeleteChangeRecordEntry(DN.rootDN());
 
-    Assert.assertEquals(entry.getDN(), DN.rootDN());
+    TestCaseUtils.assertObjectEquals(entry.getDN(), DN.rootDN());
   }
 
   /**
@@ -82,7 +82,7 @@ public final class TestDeleteChangeRecordEntry extends UtilTestCase {
 
     DeleteChangeRecordEntry entry = new DeleteChangeRecordEntry(testDN1);
 
-    Assert.assertEquals(entry.getDN(), testDN2);
+    TestCaseUtils.assertObjectEquals(entry.getDN(), testDN2);
   }
 
   /**

--- a/opendj-server-legacy/src/test/java/org/opends/server/util/TestLDIFReader.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/util/TestLDIFReader.java
@@ -268,7 +268,7 @@ public final class TestLDIFReader extends UtilTestCase {
       Entry entry = reader.readEntry();
       Assert.assertNotNull(entry);
 
-      Assert.assertEquals(entry.getName(), DN.valueOf("cn=john, dc=foo, dc=com"));
+      TestCaseUtils.assertObjectEquals(entry.getName(), DN.valueOf("cn=john, dc=foo, dc=com"));
       Assert.assertTrue(entry.hasObjectClass(getTopObjectClass()));
       Assert.assertTrue(entry.hasObjectClass(getPersonObjectClass()));
       Assert.assertTrue(entry.hasValue(getCNAttributeType(), ByteString.valueOfUtf8("john")));
@@ -355,7 +355,7 @@ public final class TestLDIFReader extends UtilTestCase {
 
       Assert.assertNotNull(entry);
 
-      Assert.assertEquals(entry.getName(), DN.valueOf("cn=anne, dc=foo, dc=com"));
+      TestCaseUtils.assertObjectEquals(entry.getName(), DN.valueOf("cn=anne, dc=foo, dc=com"));
       Assert.assertTrue(entry.hasObjectClass(getTopObjectClass()));
       Assert.assertTrue(entry.hasObjectClass(getPersonObjectClass()));
       Assert.assertTrue(entry.hasValue(getCNAttributeType(), ByteString.valueOfUtf8("anne")));
@@ -396,7 +396,7 @@ public final class TestLDIFReader extends UtilTestCase {
       add = (AddChangeRecordEntry) change;
 
       dn = DN.valueOf("cn=Fiona Jensen, ou=Marketing, dc=airius, dc=com");
-      Assert.assertEquals(add.getDN(), dn);
+      TestCaseUtils.assertObjectEquals(add.getDN(), dn);
 
       List<Attribute> attrs = new ArrayList<>();
       AttributeBuilder builder = new AttributeBuilder(getObjectClassAttributeType());
@@ -417,7 +417,7 @@ public final class TestLDIFReader extends UtilTestCase {
       delete = (DeleteChangeRecordEntry) change;
 
       dn = DN.valueOf("cn=Robert Jensen, ou=Marketing, dc=airius, dc=com");
-      Assert.assertEquals(delete.getDN(), dn);
+      TestCaseUtils.assertObjectEquals(delete.getDN(), dn);
 
       // Change record #3.
       change = reader.readChangeRecord(false);
@@ -426,10 +426,10 @@ public final class TestLDIFReader extends UtilTestCase {
 
       dn = DN
           .valueOf("cn=Paul Jensen, ou=Product Development, dc=airius, dc=com");
-      Assert.assertEquals(modifyDN.getDN(), dn);
+      TestCaseUtils.assertObjectEquals(modifyDN.getDN(), dn);
 
       rdn = RDN.valueOf("cn=paula jensen");
-      Assert.assertEquals(modifyDN.getNewRDN(), rdn);
+      TestCaseUtils.assertObjectEquals(modifyDN.getNewRDN(), rdn);
       Assert.assertNull(modifyDN.getNewSuperiorDN());
       Assert.assertTrue(modifyDN.deleteOldRDN());
 
@@ -440,12 +440,12 @@ public final class TestLDIFReader extends UtilTestCase {
 
       dn = DN
           .valueOf("ou=PD Accountants, ou=Product Development, dc=airius, dc=com");
-      Assert.assertEquals(modifyDN.getDN(), dn);
+      TestCaseUtils.assertObjectEquals(modifyDN.getDN(), dn);
 
       rdn = RDN.valueOf("ou=Product Development Accountants");
-      Assert.assertEquals(modifyDN.getNewRDN(), rdn);
+      TestCaseUtils.assertObjectEquals(modifyDN.getNewRDN(), rdn);
       dn = DN.valueOf("ou=Accounting, dc=airius, dc=com");
-      Assert.assertEquals(modifyDN.getNewSuperiorDN(), dn);
+      TestCaseUtils.assertObjectEquals(modifyDN.getNewSuperiorDN(), dn);
       Assert.assertFalse(modifyDN.deleteOldRDN());
 
       // Change record #5.
@@ -455,7 +455,7 @@ public final class TestLDIFReader extends UtilTestCase {
 
       dn = DN
           .valueOf("cn=Paula Jensen, ou=Product Development, dc=airius, dc=com");
-      Assert.assertEquals(modify.getDN(), dn);
+      TestCaseUtils.assertObjectEquals(modify.getDN(), dn);
 
       i = modify.getModifications().iterator();
 
@@ -464,14 +464,14 @@ public final class TestLDIFReader extends UtilTestCase {
       Assert.assertEquals(mod.getModificationType(), ModificationType.ADD);
       attr = Attributes.create("postaladdress",
           "123 Anystreet $ Sunnyvale, CA $ 94086");
-      Assert.assertEquals(mod.getAttribute(), attr);
+      TestCaseUtils.assertObjectEquals(mod.getAttribute(), attr);
 
       Assert.assertTrue(i.hasNext());
       mod = i.next().toModification();
       Assert.assertEquals(mod.getModificationType(),
           ModificationType.DELETE);
       attr = Attributes.empty(getDescriptionAttributeType());
-      Assert.assertEquals(mod.getAttribute(), attr);
+      TestCaseUtils.assertObjectEquals(mod.getAttribute(), attr);
 
       Assert.assertTrue(i.hasNext());
       mod = i.next().toModification();
@@ -480,14 +480,14 @@ public final class TestLDIFReader extends UtilTestCase {
       builder = new AttributeBuilder(getTelephoneNumberAttributeType());
       builder.add("+1 408 555 1234");
       builder.add("+1 408 555 5678");
-      Assert.assertEquals(mod.getAttribute(), builder.toAttribute());
+      TestCaseUtils.assertObjectEquals(mod.getAttribute(), builder.toAttribute());
 
       Assert.assertTrue(i.hasNext());
       mod = i.next().toModification();
       Assert.assertEquals(mod.getModificationType(),
           ModificationType.DELETE);
       attr = Attributes.create("facsimiletelephonenumber", "+1 408 555 9876");
-      Assert.assertEquals(mod.getAttribute(), attr);
+      TestCaseUtils.assertObjectEquals(mod.getAttribute(), attr);
 
       Assert.assertFalse(i.hasNext());
 
@@ -497,7 +497,7 @@ public final class TestLDIFReader extends UtilTestCase {
       modify = (ModifyChangeRecordEntry) change;
 
       dn = DN.valueOf("cn=Ingrid Jensen, ou=Product Support, dc=airius, dc=com");
-      Assert.assertEquals(modify.getDN(), dn);
+      TestCaseUtils.assertObjectEquals(modify.getDN(), dn);
 
       i = modify.getModifications().iterator();
 
@@ -505,7 +505,7 @@ public final class TestLDIFReader extends UtilTestCase {
       mod = i.next().toModification();
       Assert.assertEquals(mod.getModificationType(), ModificationType.REPLACE);
       attr = Attributes.empty(CoreSchema.getPostalAddressAttributeType());
-      Assert.assertEquals(mod.getAttribute(), attr);
+      TestCaseUtils.assertObjectEquals(mod.getAttribute(), attr);
 
       // Change record #7.
       change = reader.readChangeRecord(false);
@@ -521,7 +521,7 @@ public final class TestLDIFReader extends UtilTestCase {
       Assert.assertEquals(mod.getModificationType(),
           ModificationType.DELETE);
       attr = Attributes.empty(getDescriptionAttributeType());
-      Assert.assertEquals(mod.getAttribute(), attr);
+      TestCaseUtils.assertObjectEquals(mod.getAttribute(), attr);
 
       // Change record #8.
       change = reader.readChangeRecord(false);
@@ -529,7 +529,7 @@ public final class TestLDIFReader extends UtilTestCase {
       modify = (ModifyChangeRecordEntry) change;
 
       dn = DN.valueOf("uid=rogasawara, ou=\u55b6\u696d\u90e8, o=airius");
-      Assert.assertEquals(modify.getDN(), dn);
+      TestCaseUtils.assertObjectEquals(modify.getDN(), dn);
 
       i = modify.getModifications().iterator();
 
@@ -538,7 +538,7 @@ public final class TestLDIFReader extends UtilTestCase {
       Assert.assertEquals(mod.getModificationType(),
           ModificationType.DELETE);
       attr = Attributes.empty(getDescriptionAttributeType());
-      Assert.assertEquals(mod.getAttribute(), attr);
+      TestCaseUtils.assertObjectEquals(mod.getAttribute(), attr);
 
       Assert.assertFalse(i.hasNext());
 
@@ -600,7 +600,7 @@ public final class TestLDIFReader extends UtilTestCase {
       AddChangeRecordEntry add = (AddChangeRecordEntry) change;
 
       DN dn = DN.valueOf("cn=john smith, dc=com");
-      Assert.assertEquals(add.getDN(), dn);
+      TestCaseUtils.assertObjectEquals(add.getDN(), dn);
 
       Attribute attr = Attributes.create("description", TEMP_FILE_STRING);
       Assert.assertTrue(add.getAttributes().contains(attr));

--- a/opendj-server-legacy/src/test/java/org/opends/server/util/TestLDIFWriter.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/util/TestLDIFWriter.java
@@ -342,7 +342,7 @@ public final class TestLDIFWriter extends UtilTestCase {
     Entry readEntry = reader.readEntry();
     reader.close();
 
-    Assert.assertEquals(readEntry.getName(), entry.getName());
+    TestCaseUtils.assertObjectEquals(readEntry.getName(), entry.getName());
   }
 
   /**
@@ -369,7 +369,7 @@ public final class TestLDIFWriter extends UtilTestCase {
     reader.close();
 
     Assert.assertTrue(add instanceof AddChangeRecordEntry);
-    Assert.assertEquals(add.getDN(), entry.getName());
+    TestCaseUtils.assertObjectEquals(add.getDN(), entry.getName());
   }
 
   /**

--- a/opendj-server-legacy/src/test/java/org/opends/server/util/TestModifyChangeRecordEntry.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/util/TestModifyChangeRecordEntry.java
@@ -91,7 +91,7 @@ public final class TestModifyChangeRecordEntry extends UtilTestCase {
     ModifyChangeRecordEntry entry = new ModifyChangeRecordEntry(DN.rootDN(),
         modifications);
 
-    Assert.assertEquals(entry.getDN(), DN.rootDN());
+    TestCaseUtils.assertObjectEquals(entry.getDN(), DN.rootDN());
   }
 
   /**
@@ -108,7 +108,7 @@ public final class TestModifyChangeRecordEntry extends UtilTestCase {
     ModifyChangeRecordEntry entry = new ModifyChangeRecordEntry(testDN1,
         modifications);
 
-    Assert.assertEquals(entry.getDN(), testDN2);
+    TestCaseUtils.assertObjectEquals(entry.getDN(), testDN2);
   }
 
   /**
@@ -158,6 +158,6 @@ public final class TestModifyChangeRecordEntry extends UtilTestCase {
 
     RawModification first = mods.get(0);
     Assert.assertEquals(first.getModificationType(), ModificationType.ADD);
-    Assert.assertEquals(first.getAttribute().toAttribute(), attribute);
+    TestCaseUtils.assertObjectEquals(first.getAttribute().toAttribute(), attribute);
   }
 }

--- a/opendj-server-legacy/src/test/java/org/opends/server/util/TestModifyDNChangeRecordEntry.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/util/TestModifyDNChangeRecordEntry.java
@@ -75,7 +75,7 @@ public final class TestModifyDNChangeRecordEntry extends UtilTestCase {
     ModifyDNChangeRecordEntry entry = new ModifyDNChangeRecordEntry(
         DN.rootDN(), newRDN, false, newSuperiorDN);
 
-    Assert.assertEquals(entry.getDN(), DN.rootDN());
+    TestCaseUtils.assertObjectEquals(entry.getDN(), DN.rootDN());
   }
 
   /**
@@ -92,7 +92,7 @@ public final class TestModifyDNChangeRecordEntry extends UtilTestCase {
     ModifyDNChangeRecordEntry entry = new ModifyDNChangeRecordEntry(
         testDN1, newRDN, false, newSuperiorDN);
 
-    Assert.assertEquals(entry.getDN(), testDN2);
+    TestCaseUtils.assertObjectEquals(entry.getDN(), testDN2);
   }
 
   /**
@@ -121,7 +121,7 @@ public final class TestModifyDNChangeRecordEntry extends UtilTestCase {
     ModifyDNChangeRecordEntry entry =
          new ModifyDNChangeRecordEntry(DN.rootDN(), newRDN, false, newSuperiorDN);
 
-    Assert.assertEquals(entry.getNewRDN(), newRDN);
+    TestCaseUtils.assertObjectEquals(entry.getNewRDN(), newRDN);
   }
 
   /**
@@ -135,8 +135,7 @@ public final class TestModifyDNChangeRecordEntry extends UtilTestCase {
     ModifyDNChangeRecordEntry entry =
          new ModifyDNChangeRecordEntry(DN.rootDN(), newRDN, false, newSuperiorDN);
 
-    Assert
-        .assertEquals(entry.getNewSuperiorDN(), newSuperiorDN);
+    TestCaseUtils.assertObjectEquals(entry.getNewSuperiorDN(), newSuperiorDN);
   }
 
   /**

--- a/opendj-server-legacy/src/test/java/org/opends/server/workflowelement/localbackend/LocalBackendWorkflowElementTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/workflowelement/localbackend/LocalBackendWorkflowElementTest.java
@@ -163,10 +163,10 @@ public class LocalBackendWorkflowElementTest extends DirectoryServerTestCase
       TestCaseUtils.initializeMemoryBackend(childID1, child1, true);
       TestCaseUtils.initializeMemoryBackend(strangerID, stranger, true);
 
-      assertEquals(getMatchedDN("cn=user," + parent), DN.valueOf(parent));
-      assertEquals(getMatchedDN("cn=user," + child1), DN.valueOf(child1));
-      assertEquals(getMatchedDN("cn=user," + child2), DN.valueOf(parent));
-      assertEquals(getMatchedDN("cn=user," + stranger), DN.valueOf(stranger));
+      TestCaseUtils.assertObjectEquals(getMatchedDN("cn=user," + parent), DN.valueOf(parent));
+      TestCaseUtils.assertObjectEquals(getMatchedDN("cn=user," + child1), DN.valueOf(child1));
+      TestCaseUtils.assertObjectEquals(getMatchedDN("cn=user," + child2), DN.valueOf(parent));
+      TestCaseUtils.assertObjectEquals(getMatchedDN("cn=user," + stranger), DN.valueOf(stranger));
     }
     finally
     {


### PR DESCRIPTION
This PR tries to fix unit tests in opendj-server-legacy module.

Currently tests are non-working and are not part of our CI pipeline - they are activated only under `precommit` profile. My goal was to fix all failing unit tests so that we can add this profile to our GitHub Action.

I was able to fix quite a few things, but there are still failing tests. I need to put this on hold right now but it makes sense to merge this PR so that someone else can continue.