### PR TITLE
Skip tests in publish pipeline.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,6 +41,8 @@ jobs:
         with:
           context: .
           builder: ${{ steps.buildx.outputs.name }}
+          build-args: |
+            MAVEN_BUILD_ARGS=-DskipTests
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,10 +10,10 @@ WORKDIR /project
 COPY . .
 
 # Perform actual Wren:DS build
-ARG BUILD_ARGS
+ARG MAVEN_BUILD_ARGS
 RUN \
   --mount=type=cache,target=/root/.m2 \
-  mvn package ${BUILD_ARGS}
+  mvn package ${MAVEN_BUILD_ARGS}
 
 # Extract built artifact into target directory
 RUN \


### PR DESCRIPTION
I added skipping of tests in publish pipeline because of their instability. Release will be tested in the build pipeline.