### PR TITLE
Fix Docker entrypoint not finding existing instance data

### DIFF
--- a/.docker/docker-entrypoint.sh
+++ b/.docker/docker-entrypoint.sh
@@ -1,6 +1,9 @@
-#!/bin/bash -e
+#!/bin/bash -eu
 
-if [ ! -d $INSTANCE_DIR/config ]; then
+# This file is created during Docker build and should always be present
+INSTANCE_DIR="$(</opt/wrends/instance.loc)"
+
+if [ ! -d "$INSTANCE_DIR/config" ]; then
   source ./bootstrap/setup.sh
   echo "First start..."
   first_start

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,7 @@ ENV PATH="${PATH}:/opt/wrends/bin"
 # Prepare Wren:DS instance directory
 ARG INSTANCE_DIR="/opt/wrends/instance"
 RUN echo ${INSTANCE_DIR} > /opt/wrends/instance.loc
-RUN mkdir -p ${INSTANCE_DIR} ${INSTANCE_DIR}/lib/extension
+RUN mkdir -p ${INSTANCE_DIR} ${INSTANCE_DIR}/lib/extensions
 VOLUME ${INSTANCE_DIR}
 
 EXPOSE ${LDAP_PORT} ${LDAPS_PORT} ${ADMIN_CONNECTOR_PORT}


### PR DESCRIPTION
Instance directory is now read from `instance.loc` file which is created during Docker image build, or can be overridden by a mount during deployment.

In addition to this change, I've fixed path `$INSTANCE_DIR/lib/extensions` which is created during Docker image build and checked during Wren:DS startup, as it was logging warnings because the path created was in fact `lib/extension` (singular).

Fixes #80.