### PR TITLE
Switch to UBI based Temurin image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,13 +10,14 @@ jobs:
         java: [8, 11, 17]
     name: "Java ${{ matrix.java }} build"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           java-version: ${{ matrix.java }}
+          distribution: 'temurin'
       - name: Cache Maven packages
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN \
   unzip opendj-server-legacy/target/package/wrends-${WRENDS_VERSION}.zip -d /build
 
 
-FROM eclipse-temurin:17-jre
+FROM eclipse-temurin:17-jre-ubi9-minimal
 
 # Set environment variables
 ENV \
@@ -38,8 +38,8 @@ ENV \
 # Create wrends user
 ARG WRENDS_UID=1000
 ARG WRENDS_GID=1000
-RUN addgroup --gid ${WRENDS_GID} wrends && \
-  adduser --uid ${WRENDS_UID} --gid ${WRENDS_GID} --system wrends
+RUN groupadd --gid ${WRENDS_GID} wrends && \
+  useradd --uid ${WRENDS_UID} --gid ${WRENDS_GID} --system wrends
 
 # Deploy wrends project
 COPY --chown=wrends:root --from=project-build /build/wrends /opt/wrends


### PR DESCRIPTION
This PR changes base Eclipse Temurin docker image from Ubuntu-based image to RedHat's Universal Base Image - Minimal.  This change has already been made in the other projects (e.g. Wren:IDM https://github.com/WrenSecurity/wrenidm/pull/191)