### PR TITLE
Upgrade to wrensec-parent 4.2.0 and remove self-referencing BOM

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [8, 11, 17]
+        java: [11, 17, 21]
     name: "Java ${{ matrix.java }} build"
     steps:
       - uses: actions/checkout@v4

--- a/opendj-bom/pom.xml
+++ b/opendj-bom/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wrensecurity</groupId>
         <artifactId>wrensec-parent</artifactId>
-        <version>3.5.1</version>
+        <version>4.2.0</version>
         <relativePath />
     </parent>
 
@@ -65,28 +65,8 @@
         </repository>
     </repositories>
 
-    <properties>
-        <wrensec-commons.version>22.3.0</wrensec-commons.version>
-    </properties>
-
     <dependencyManagement>
         <dependencies>
-            <!-- Wren Security BOM -->
-            <dependency>
-                <groupId>org.wrensecurity.commons</groupId>
-                <artifactId>commons-bom</artifactId>
-                <version>${wrensec-commons.version}</version>
-                <scope>import</scope>
-                <type>pom</type>
-            </dependency>
-
-            <!-- I18N framework -->
-            <dependency>
-                <groupId>org.wrensecurity.commons</groupId>
-                <artifactId>i18n-slf4j</artifactId>
-                <version>${wrensec-commons.version}</version>
-            </dependency>
-
             <!-- Wren:DS SDK -->
             <dependency>
                 <groupId>org.wrensecurity.wrends</groupId>
@@ -110,13 +90,6 @@
                 <groupId>org.wrensecurity.wrends</groupId>
                 <artifactId>opendj-rest2ldap</artifactId>
                 <version>${project.version}</version>
-            </dependency>
-
-            <!-- Other -->
-            <dependency>
-                <groupId>com.github.stephenc.jcip</groupId>
-                <artifactId>jcip-annotations</artifactId>
-                <version>1.0-1</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/opendj-cli/pom.xml
+++ b/opendj-cli/pom.xml
@@ -35,6 +35,7 @@
         <dependency>
             <groupId>org.wrensecurity.wrends</groupId>
             <artifactId>opendj-core</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>

--- a/opendj-config/pom.xml
+++ b/opendj-config/pom.xml
@@ -55,6 +55,7 @@
         <dependency>
             <groupId>org.wrensecurity.wrends</groupId>
             <artifactId>opendj-core</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>
@@ -67,6 +68,7 @@
         <dependency>
             <groupId>org.wrensecurity.wrends</groupId>
             <artifactId>opendj-cli</artifactId>
+            <version>${project.version}</version>
         </dependency>
     </dependencies>
 

--- a/opendj-doc-maven-plugin/pom.xml
+++ b/opendj-doc-maven-plugin/pom.xml
@@ -38,6 +38,7 @@
         <dependency>
             <groupId>org.wrensecurity.wrends</groupId>
             <artifactId>opendj-core</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>

--- a/opendj-dsml-servlet/pom.xml
+++ b/opendj-dsml-servlet/pom.xml
@@ -38,11 +38,15 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>com.sun.xml.ws</groupId>
+            <artifactId>jaxws-rt</artifactId>
+	    </dependency>
+
     	<!-- Servlet API -->
         <dependency>
       		<groupId>javax.servlet</groupId>
       		<artifactId>javax.servlet-api</artifactId>
-      		<version>3.1.0</version>
             <scope>provided</scope>
     	</dependency>
 
@@ -66,6 +70,7 @@
         <dependency>
             <groupId>org.wrensecurity.wrends</groupId>
             <artifactId>opendj-core</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <!-- Wren:DS Server dependencies -->

--- a/opendj-grizzly/pom.xml
+++ b/opendj-grizzly/pom.xml
@@ -39,11 +39,13 @@
         <dependency>
             <groupId>org.wrensecurity.wrends</groupId>
             <artifactId>opendj-core</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.wrensecurity.wrends</groupId>
             <artifactId>opendj-core</artifactId>
+            <version>${project.version}</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/opendj-ldap-sdk-examples/pom.xml
+++ b/opendj-ldap-sdk-examples/pom.xml
@@ -33,11 +33,13 @@
         <dependency>
             <groupId>org.wrensecurity.wrends</groupId>
             <artifactId>opendj-core</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.wrensecurity.wrends</groupId>
             <artifactId>opendj-grizzly</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>

--- a/opendj-ldap-toolkit/pom.xml
+++ b/opendj-ldap-toolkit/pom.xml
@@ -44,11 +44,13 @@
         <dependency>
             <groupId>org.wrensecurity.wrends</groupId>
             <artifactId>opendj-core</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.wrensecurity.wrends</groupId>
             <artifactId>opendj-grizzly</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>
@@ -69,11 +71,13 @@
         <dependency>
             <groupId>org.wrensecurity.wrends</groupId>
             <artifactId>opendj-cli</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.wrensecurity.wrends</groupId>
             <artifactId>opendj-core</artifactId>
+            <version>${project.version}</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/opendj-openidm-account-change-notification-handler/pom.xml
+++ b/opendj-openidm-account-change-notification-handler/pom.xml
@@ -36,12 +36,14 @@
         <dependency>
             <groupId>org.wrensecurity.wrends</groupId>
             <artifactId>opendj-core</artifactId>
+            <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>org.wrensecurity.wrends</groupId>
             <artifactId>opendj-config</artifactId>
+            <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
 

--- a/opendj-rest2ldap-servlet/pom.xml
+++ b/opendj-rest2ldap-servlet/pom.xml
@@ -51,11 +51,13 @@
         <dependency>
             <groupId>org.wrensecurity.wrends</groupId>
             <artifactId>opendj-rest2ldap</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.wrensecurity.wrends</groupId>
             <artifactId>opendj-grizzly</artifactId>
+            <version>${project.version}</version>
         </dependency>
     </dependencies>
 

--- a/opendj-rest2ldap/pom.xml
+++ b/opendj-rest2ldap/pom.xml
@@ -40,6 +40,7 @@
         <dependency>
             <groupId>org.wrensecurity.wrends</groupId>
             <artifactId>opendj-core</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>

--- a/opendj-server-legacy/pom.xml
+++ b/opendj-server-legacy/pom.xml
@@ -71,11 +71,13 @@
         <dependency>
             <groupId>org.wrensecurity.wrends</groupId>
             <artifactId>opendj-cli</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.wrensecurity.wrends</groupId>
             <artifactId>opendj-rest2ldap</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>
@@ -86,6 +88,7 @@
         <dependency>
             <groupId>org.wrensecurity.wrends</groupId>
             <artifactId>opendj-config</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>
@@ -99,6 +102,7 @@
         <dependency>
             <groupId>org.wrensecurity.wrends</groupId>
             <artifactId>opendj-server</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>

--- a/opendj-server-legacy/src/main/java/org/opends/server/replication/server/changelog/api/AbortedChangelogCursorException.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/replication/server/changelog/api/AbortedChangelogCursorException.java
@@ -15,8 +15,6 @@
  */
 package org.opends.server.replication.server.changelog.api;
 
-import javax.annotation.Generated;
-
 import org.forgerock.i18n.LocalizableMessage;
 
 /**
@@ -28,7 +26,6 @@ import org.forgerock.i18n.LocalizableMessage;
 public class AbortedChangelogCursorException extends ChangelogException
 {
 
-  @Generated("Eclipse")
   private static final long serialVersionUID = -2123770048083474999L;
 
   /**

--- a/opendj-server/pom.xml
+++ b/opendj-server/pom.xml
@@ -45,16 +45,19 @@
         <dependency>
             <groupId>org.wrensecurity.wrends</groupId>
             <artifactId>opendj-core</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.wrensecurity.wrends</groupId>
             <artifactId>opendj-grizzly</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.wrensecurity.wrends</groupId>
             <artifactId>opendj-config</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>
@@ -75,6 +78,7 @@
         <dependency>
             <groupId>org.wrensecurity.wrends</groupId>
             <artifactId>opendj-core</artifactId>
+            <version>${project.version}</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
@@ -87,6 +91,7 @@
         <dependency>
             <groupId>org.wrensecurity.wrends</groupId>
             <artifactId>opendj-cli</artifactId>
+            <version>${project.version}</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wrensecurity</groupId>
         <artifactId>wrensec-parent</artifactId>
-        <version>3.5.1</version>
+        <version>4.2.0</version>
         <relativePath />
     </parent>
 
@@ -91,6 +91,8 @@
     </repositories>
 
     <properties>
+        <pgpVerifyKeysVersion>1.9.1</pgpVerifyKeysVersion>
+
         <product.name>Wren:DS</product.name>
         <product.name.lowercase>wrends</product.name.lowercase>
         <product.locales>ca_ES,es,de,fr,ja,ko,pl,zh_CN,zh_TW</product.locales>
@@ -99,6 +101,7 @@
         <freemarker.version>2.3.24-incubating</freemarker.version>
         <grizzly-framework.version>2.3.28</grizzly-framework.version>
         <metrics-core.version>3.1.2</metrics-core.version>
+        <wrensec-commons.version>22.3.0</wrensec-commons.version>
 
         <!-- OSGi bundles properties -->
         <opendj.osgi.import.additional />
@@ -115,26 +118,44 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>org.wrensecurity.wrends</groupId>
-                <artifactId>opendj-bom</artifactId>
-                <version>${project.version}</version>
-                <scope>import</scope>
-                <type>pom</type>
+                <groupId>com.github.stephenc.jcip</groupId>
+                <artifactId>jcip-annotations</artifactId>
+                <version>1.0-1</version>
             </dependency>
 
-            <!-- Dropwizard metrics-core -->
+	        <dependency>
+			    <groupId>com.sun.xml.ws</groupId>
+			    <artifactId>jaxws-ri</artifactId>
+			    <version>2.3.7</version>
+			    <type>pom</type>
+			    <scope>import</scope>
+			</dependency>
+
             <dependency>
                 <groupId>io.dropwizard.metrics</groupId>
                 <artifactId>metrics-core</artifactId>
                 <version>${metrics-core.version}</version>
             </dependency>
 
-            <!-- Commons Build Tools -->
             <dependency>
                 <groupId>org.wrensecurity</groupId>
                 <artifactId>wrensec-build-tools</artifactId>
-                <version>${wrenBuildToolsVersion}</version>
+                <version>${wrensecBuildToolsVersion}</version>
                 <scope>test</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.wrensecurity.commons</groupId>
+                <artifactId>commons-bom</artifactId>
+                <version>${wrensec-commons.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+
+            <dependency>
+                <groupId>org.wrensecurity.commons</groupId>
+                <artifactId>i18n-slf4j</artifactId>
+                <version>${wrensec-commons.version}</version>
             </dependency>
 
             <dependency>
@@ -287,7 +308,7 @@
                     <?m2e execute onConfiguration?>
                     <groupId>org.wrensecurity.commons</groupId>
                     <artifactId>i18n-maven-plugin</artifactId>
-                    <version>22.3.0</version>
+                    <version>${wrensec-commons.version}</version>
                 </plugin>
 
                 <!-- This is needed to use annotations in maven plugins with maven 3.0.x -->
@@ -295,7 +316,6 @@
                     <?m2e execute onConfiguration?>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-plugin-plugin</artifactId>
-                    <version>3.2</version>
                     <configuration>
                         <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
                     </configuration>


### PR DESCRIPTION
This PR mainly contains upgrade to the newest wrensec-parent release. However I have also removed the self-referencing BOM, which is Maven anti-patter and would break with Maven 4.

Changing the parent forced me also to upgrade JAX WS dependencies (now using Jakarta-based release, while the servlet is still Javax).