### PR TITLE
Fix unavailable monitoring attributes over JMX

### DIFF
--- a/opendj-server-legacy/src/main/java/org/opends/server/core/DirectoryServer.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/core/DirectoryServer.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2010 Sun Microsystems, Inc.
  * Portions Copyright 2010-2016 ForgeRock AS.
+ * Portions Copyright 2025 Wren Security.
  */
 package org.opends.server.core;
 
@@ -2721,6 +2722,11 @@ public final class DirectoryServer
         if (mBean != null)
         {
           mBean.removeMonitorProvider(provider);
+          if (mBean.getMonitorProviders().isEmpty() && mBean.getAlertGenerators().isEmpty())
+          {
+            directoryServer.mBeans.remove(monitorDN);
+            directoryServer.mBeanServer.unregisterMBean(mBean.getObjectName());
+          }
         }
       }
       catch (Exception e)

--- a/opendj-server-legacy/src/main/java/org/opends/server/replication/service/ReplicationBroker.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/replication/service/ReplicationBroker.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2010 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2025 Wren Security.
  */
 package org.opends.server.replication.service;
 
@@ -3250,14 +3251,30 @@ public class ReplicationBroker
     return monitor.getMonitorInstanceName();
   }
 
+  /**
+   * Updates the currently connected replication server reference.
+   * <p>
+   * If the new replication server differs from the previous one, this method will:
+   * <ul>
+   * <li>deregister the replication monitor associated with the old server,
+   * <li>close the old replication session,
+   * <li>and register a replication monitor for the new server.
+   *
+   * @param newRS The new {@link ConnectedRS} instance to set as the currently connected replication server.
+   * @return The newly set {@link ConnectedRS} instance.
+   */
   private ConnectedRS setConnectedRS(final ConnectedRS newRS)
   {
-    final ConnectedRS oldRS = connectedRS.getAndSet(newRS);
-    if (!oldRS.equals(newRS) && oldRS.isConnected())
+    ConnectedRS oldRS = connectedRS.get();
+    if (!oldRS.equals(newRS))
     {
       // monitor name is changing, deregister before registering again
       deregisterReplicationMonitor();
-      oldRS.session.close();
+      if (oldRS.isConnected())
+      {
+        oldRS.session.close();
+      }
+      connectedRS.set(newRS);
       registerReplicationMonitor();
     }
     return newRS;


### PR DESCRIPTION
When the `ReplicationBroker` switched to a different RS, the replication monitor MBean could remain registered under the old instance. As a result, JMX clients (e.g. JConsole) displayed "Unavailable" for Directory Server replication monitoring attributes.

Fixes:

- `ReplicationBroker#setConnectedRS()`: Deregister the `ReplicationMonitor` before its instance name[^getMonitorInstanceName] changes, otherwise the deregistration will not be successful.
- `DirectoryServer#deregisterMonitorProvider()`: when an MBean has no monitor providers, remove it from the local registry and unregister it from the `MBeanServer` to avoid stale MBeans.

[^getMonitorInstanceName]: https://github.com/WrenSecurity/wrends/blob/09cf0ade4fd10e5e1e7aa7b220e0b7a616a89cfc/opendj-server-legacy/src/main/java/org/opends/server/replication/service/ReplicationMonitor.java#L59

Before | After
--- | ---
<img width="1761" height="1194" alt="Screenshot_20250909_100932" src="https://github.com/user-attachments/assets/e9e78a9b-4b0d-4c1c-9dbb-6b3d88363223" /> | <img width="1866" height="1369" alt="Screenshot_20250909_100643" src="https://github.com/user-attachments/assets/de877a39-fc84-47b4-b5aa-9eb62a856032" />

The issue did not occur when reading monitoring attributes via LDAP.
