### PR TITLE
Fix replication late queue handling (#96)

### DIFF
--- a/opendj-server-legacy/src/main/java/org/opends/server/replication/server/MsgQueue.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/replication/server/MsgQueue.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2010 Sun Microsystems, Inc.
  * Portions Copyright 2012-2016 ForgeRock AS.
+ * Portions copyright 2025 Wren Security
  */
 package org.opends.server.replication.server;
 
@@ -58,6 +59,19 @@ public class MsgQueue
     synchronized (lock)
     {
       return map.get(map.firstKey());
+    }
+  }
+
+  /**
+   * Return the last UpdateMsg in the MsgQueue.
+   *
+   * @return The last UpdateMsg in the MsgQueue.
+   */
+  public UpdateMsg last()
+  {
+    synchronized (lock)
+    {
+      return map.get(map.lastKey());
     }
   }
 


### PR DESCRIPTION
~~I have disabled reading `ReplicaOfflineMsg` into the late queue as it always breaks the processing in one way or another; i.e. any solution that tries to handle those messages ends up with some corner case that is not solvable without actually tracking their CSN by the server state.~~

~~Hopefully there shouldn't be any severe consequences to this change as not receiving `ReplicaOfflineMsg` is equivalent to the replica being forcefully shut down. The message will be delivered if the RS handler remains in the `following` state.~~

Made an alternative attempt at intentionally overflowing late queue to make sure it ends with a message that contains an actual LDAP operation.