### PR TITLE
Fix work queue race condition

### DIFF
--- a/opendj-server-legacy/src/main/java/org/opends/server/extensions/ParallelWorkQueue.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/extensions/ParallelWorkQueue.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2010 Sun Microsystems, Inc.
  * Portions Copyright 2013-2016 ForgeRock AS.
+ * Portions Copyright 2026 Wren Security
  */
 package org.opends.server.extensions;
 
@@ -237,11 +238,10 @@ public class ParallelWorkQueue
    *
    * @param  workerThread  The worker thread that is requesting the operation.
    *
-   * @return  The next operation that should be processed, or <CODE>null</CODE>
-   *          if the server is shutting down and no more operations will be
-   *          processed.
+   * @return  Flag indicating the worker should continue polling for work or if
+   *          the server is shutting down and no more operations will be processed.
    */
-  public Operation nextOperation(ParallelWorkerThread workerThread)
+  public boolean nextOperation(ParallelWorkerThread workerThread)
   {
     return retryNextOperation(workerThread, 0);
   }
@@ -249,20 +249,18 @@ public class ParallelWorkQueue
   /**
    * Retrieves the next operation that should be processed by one of the worker
    * threads following a previous failure attempt.  A maximum of five
-   * consecutive failures will be allowed before returning <CODE>null</CODE>,
-   * which will cause the associated thread to exit.
+   * consecutive failures will be allowed before abandoning the operation.
    *
    * @param  workerThread  The worker thread that is requesting the operation.
    * @param  numFailures   The number of consecutive failures that the worker
    *                       thread has experienced so far.  If this gets too
-   *                       high, then this method will return <CODE>null</CODE>
+   *                       high, then this method will return <CODE>false</CODE>
    *                       rather than retrying.
    *
-   * @return  The next operation that should be processed, or <CODE>null</CODE>
-   *          if the server is shutting down and no more operations will be
-   *          processed, or if there have been too many consecutive failures.
+   * @return  Flag indicating the worker should continue polling for work, or if
+   *          the server is shutting down and no more operations will be processed.
    */
-  private Operation retryNextOperation(
+  private boolean retryNextOperation(
                                        ParallelWorkerThread workerThread,
                                        int numFailures)
   {
@@ -289,7 +287,7 @@ public class ParallelWorkQueue
             }
 
             workerThread.setStoppedByReducedThreadNumber();
-            return null;
+            return false;
           }
         }
         catch (Exception e)
@@ -299,15 +297,16 @@ public class ParallelWorkQueue
       }
     }
 
-    if (shutdownRequested || numFailures > MAX_RETRY_COUNT)
+    if (shutdownRequested)
     {
-      if (numFailures > MAX_RETRY_COUNT)
-      {
-        logger.error(ERR_CONFIG_WORK_QUEUE_TOO_MANY_FAILURES, Thread
-            .currentThread().getName(), numFailures, MAX_RETRY_COUNT);
-      }
+      return false;
+    }
 
-      return null;
+    if (numFailures > MAX_RETRY_COUNT)
+    {
+      logger.error(ERR_CONFIG_WORK_QUEUE_TOO_MANY_FAILURES, Thread
+          .currentThread().getName(), numFailures, MAX_RETRY_COUNT);
+      return true;
     }
 
     try
@@ -324,7 +323,7 @@ public class ParallelWorkQueue
           // we should shutdown, and if not then just check again.
           if (shutdownRequested)
           {
-            return null;
+            return false;
           }
           else if (killThreads)
           {
@@ -346,7 +345,7 @@ public class ParallelWorkQueue
                   }
 
                   workerThread.setStoppedByReducedThreadNumber();
-                  return null;
+                  return false;
                 }
               }
               catch (Exception e)
@@ -358,7 +357,8 @@ public class ParallelWorkQueue
         }
         else
         {
-          return nextOperation;
+          workerThread.assignOperation(nextOperation);
+          return true;
         }
       }
     }

--- a/opendj-server-legacy/src/main/java/org/opends/server/extensions/ParallelWorkerThread.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/extensions/ParallelWorkerThread.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2009 Sun Microsystems, Inc.
  * Portions Copyright 2013-2016 ForgeRock AS.
+ * Portions Copyright 2026 Wren Security
  */
 package org.opends.server.extensions;
 
@@ -53,10 +54,10 @@ public class ParallelWorkerThread
   private boolean stoppedByReducedThreadNumber;
 
   /** Indicates whether this thread is currently waiting for work. */
-  private boolean waitingForWork;
+  private volatile boolean waitingForWork;
 
   /** The operation that this worker thread is currently processing. */
-  private Operation operation;
+  private volatile Operation operation;
 
   /** The handle to the actual thread for this worker thread. */
   private Thread workerThread;
@@ -116,7 +117,19 @@ public class ParallelWorkerThread
     return isAlive() && operation != null;
   }
 
-
+  /**
+   * Assign operation to this thread. This should be called only as a result of this
+   * thread requesting new work from the work queue.
+   * @param operation The operation that should be assigned.
+   */
+  void assignOperation(Operation operation)
+  {
+    if (this.operation != null)
+    {
+      throw new IllegalStateException("Can not assign operation to an active worker thread");
+    }
+    this.operation = operation;
+  }
 
   /**
    * Operates in a loop, retrieving the next request from the work queue,
@@ -132,16 +145,21 @@ public class ParallelWorkerThread
       try
       {
         waitingForWork = true;
-        operation = null;
-        operation = workQueue.nextOperation(this);
-        waitingForWork = false;
-
+        try
+        {
+          if (!workQueue.nextOperation(this)) {
+              break; // shutdown requested
+          }
+        }
+        finally
+        {
+          waitingForWork = false;
+        }
 
         if (operation == null)
         {
-          // The operation may be null if the server is shutting down.  If that
-          // is the case, then break out of the while loop.
-          break;
+          // Operation has not been assigned by work queue for some reason, keep trying.
+          continue;
         }
         else
         {
@@ -196,6 +214,8 @@ public class ParallelWorkerThread
           logger.traceException(t2);
         }
       }
+
+      operation = null; // cleanup operation reference
     }
 
     // If we have gotten here, then we presume that the server thread is

--- a/opendj-server-legacy/src/main/java/org/opends/server/extensions/TraditionalWorkQueue.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/extensions/TraditionalWorkQueue.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2010 Sun Microsystems, Inc.
  * Portions Copyright 2013-2016 ForgeRock AS.
+ * Portions Copyright 2026 Wren Security
  */
 package org.opends.server.extensions;
 
@@ -27,7 +28,6 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock.ReadLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock.WriteLock;
-
 import org.forgerock.i18n.LocalizableMessage;
 import org.forgerock.i18n.slf4j.LocalizedLogger;
 import org.forgerock.opendj.config.server.ConfigException;
@@ -373,11 +373,10 @@ public class TraditionalWorkQueue extends WorkQueue<TraditionalWorkQueueCfg>
    *
    * @param workerThread
    *          The worker thread that is requesting the operation.
-   * @return The next operation that should be processed, or <CODE>null</CODE>
-   *         if the server is shutting down and no more operations will be
-   *         processed.
+   * @return Flag indicating the worker should continue polling for work or if
+   *          the server is shutting down and no more operations will be processed.
    */
-  public Operation nextOperation(TraditionalWorkerThread workerThread)
+  public boolean nextOperation(TraditionalWorkerThread workerThread)
   {
     return retryNextOperation(workerThread, 0);
   }
@@ -385,20 +384,18 @@ public class TraditionalWorkQueue extends WorkQueue<TraditionalWorkQueueCfg>
   /**
    * Retrieves the next operation that should be processed by one of the worker
    * threads following a previous failure attempt. A maximum of five consecutive
-   * failures will be allowed before returning <CODE>null</CODE>, which will
-   * cause the associated thread to exit.
+   * failures will be allowed before abandoning the operation.
    *
    * @param workerThread
    *          The worker thread that is requesting the operation.
    * @param numFailures
    *          The number of consecutive failures that the worker thread has
    *          experienced so far. If this gets too high, then this method will
-   *          return <CODE>null</CODE> rather than retrying.
-   * @return The next operation that should be processed, or <CODE>null</CODE>
-   *         if the server is shutting down and no more operations will be
-   *         processed, or if there have been too many consecutive failures.
+   *          return <CODE>false</CODE> rather than retrying.
+   * @return Flag indicating the worker should continue polling for work, or if
+   *          the server is shutting down and no more operations will be processed.
    */
-  private Operation retryNextOperation(TraditionalWorkerThread workerThread,
+  private boolean retryNextOperation(TraditionalWorkerThread workerThread,
       int numFailures)
   {
     // See if we should kill off this thread. This could be necessary if the
@@ -409,12 +406,12 @@ public class TraditionalWorkQueue extends WorkQueue<TraditionalWorkQueueCfg>
     {
       if (shutdownRequested)
       {
-        return null;
+        return false;
       }
 
       if (killThreads && tryKillThisWorkerThread(workerThread))
       {
-        return null;
+        return false;
       }
 
       if (numFailures > MAX_RETRY_COUNT)
@@ -422,7 +419,7 @@ public class TraditionalWorkQueue extends WorkQueue<TraditionalWorkQueueCfg>
         logger.error(ERR_CONFIG_WORK_QUEUE_TOO_MANY_FAILURES, Thread
             .currentThread().getName(), numFailures, MAX_RETRY_COUNT);
 
-        return null;
+        return true;
       }
 
       while (true)
@@ -430,7 +427,8 @@ public class TraditionalWorkQueue extends WorkQueue<TraditionalWorkQueueCfg>
         Operation nextOperation = opQueue.poll(5, TimeUnit.SECONDS);
         if (nextOperation != null)
         {
-          return nextOperation;
+          workerThread.assignOperation(nextOperation);
+          return true;
         }
 
         // There was no work to do in the specified length of time. Release the
@@ -442,12 +440,12 @@ public class TraditionalWorkQueue extends WorkQueue<TraditionalWorkQueueCfg>
 
         if (shutdownRequested)
         {
-          return null;
+          return false;
         }
 
         if (killThreads && tryKillThisWorkerThread(workerThread))
         {
-          return null;
+          return false;
         }
       }
     }
@@ -461,7 +459,7 @@ public class TraditionalWorkQueue extends WorkQueue<TraditionalWorkQueueCfg>
       // down, in which case we should return null.
       if (shutdownRequested)
       {
-        return null;
+        return false;
       }
 
       // If we've gotten here, then the worker thread was interrupted for some

--- a/opendj-server-legacy/src/main/java/org/opends/server/extensions/TraditionalWorkerThread.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/extensions/TraditionalWorkerThread.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2010 Sun Microsystems, Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 Wren Security
  */
 package org.opends.server.extensions;
 
@@ -51,7 +52,7 @@ public class TraditionalWorkerThread
   private boolean stoppedByReducedThreadNumber;
 
   /** Indicates whether this thread is currently waiting for work. */
-  private boolean waitingForWork;
+  private volatile boolean waitingForWork;
 
   /** The operation that this worker thread is currently processing. */
   private volatile Operation operation;
@@ -114,7 +115,19 @@ public class TraditionalWorkerThread
     return isAlive() && operation != null;
   }
 
-
+  /**
+   * Assign operation to this thread. This should be called only as a result of this
+   * thread requesting new work from the work queue.
+   * @param operation The operation that should be assigned.
+   */
+  void assignOperation(Operation operation)
+  {
+    if (this.operation != null)
+    {
+      throw new IllegalStateException("Can not assign operation to an active worker thread");
+    }
+    this.operation = operation;
+  }
 
   /**
    * Operates in a loop, retrieving the next request from the work queue,
@@ -130,16 +143,21 @@ public class TraditionalWorkerThread
       try
       {
         waitingForWork = true;
-        operation = null; // this line is necessary because next line can block
-        operation = workQueue.nextOperation(this);
-        waitingForWork = false;
-
+        try
+        {
+          if (!workQueue.nextOperation(this)) {
+              break; // shutdown requested
+          }
+        }
+        finally
+        {
+          waitingForWork = false;
+        }
 
         if (operation == null)
         {
-          // The operation may be null if the server is shutting down.  If that
-          // is the case, then break out of the while loop.
-          break;
+          // Operation has not been assigned by work queue for some reason, keep trying.
+          continue;
         }
         else
         {
@@ -196,6 +214,8 @@ public class TraditionalWorkerThread
           logger.traceException(t2);
         }
       }
+
+      operation = null; // cleanup operation reference
     }
 
     // If we have gotten here, then we presume that the server thread is


### PR DESCRIPTION
This PR changes the way how worker threads allocate their work (via callback). I made the change as a reaction to flaky (`TraditionalWorkQueueTestCase`) test that was occasionally able to call queue's `isIdle()` method at the moment the only task in the queue was already handed over to a worker thread but before the thread registers it within its state property.

I am not sure if this is a good approach how to solve the original issue or if it was possible to rewrite the tests somehow so they don't suffer from the race condition. The changes are on a non-public API, so it should be OK. ~~Nevertheless I am marking this as a DRAFT so it sits here for a while before it potentially gets merged.~~

UPDATE: issue happened again, changing to Ready for review / merge.