### PR TITLE
Add backport workflow

### DIFF
--- a/.github/workflows/check-backport.yml
+++ b/.github/workflows/check-backport.yml
@@ -1,0 +1,20 @@
+name: Check-backport
+on:
+  pull_request_target:
+    types: ["closed", "labeled"]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  backport:
+    if: ${{ github.event.pull_request.merged }}
+    uses: WrenSecurity/.github/.github/workflows/backport-prepare.yml@main
+    with:
+      event: ${{ github.event.action }}
+      label: ${{ github.event.action == 'labeled' && github.event.label.name || '' }}
+      pull_request: ${{ toJSON(github.event.pull_request) }}
+      backport_app_id: ${{ vars.BACKPORT_APP_ID }}
+    secrets:
+      backport_app_key: ${{ secrets.BACKPORT_APP_KEY }}


### PR DESCRIPTION
This pull request adds a workflow to automate backporting checks when a pull request is closed or labeled. The backport is executed only if the pull request is merged. 
