### PR TITLE
Fix unwanted buffer reuse after duplicate

### DIFF
--- a/opendj-grizzly/src/main/java/org/forgerock/opendj/grizzly/LDAPClientFilter.java
+++ b/opendj-grizzly/src/main/java/org/forgerock/opendj/grizzly/LDAPClientFilter.java
@@ -425,8 +425,8 @@ final class LDAPClientFilter extends LDAPBaseFilter {
             buffer.mark();
             if (!reader.elementAvailable()) {
                 buffer.reset();
-                // We need to create a duplicate because buffer will be closed by the reader (try-with-resources)
-                return ctx.getStopAction(buffer.duplicate());
+                // We need to split because buffer will be closed by the reader (try-with-resources)
+                return ctx.getStopAction(buffer.split(0));
             }
             final int length = reader.peekLength();
             final Buffer remainder = buffer.remaining() > length ? buffer.split(buffer.position() + length) : null;

--- a/opendj-grizzly/src/main/java/org/forgerock/opendj/grizzly/LdapCodec.java
+++ b/opendj-grizzly/src/main/java/org/forgerock/opendj/grizzly/LdapCodec.java
@@ -60,8 +60,8 @@ abstract class LdapCodec extends LDAPBaseFilter {
                 final int mark = buffer.position();
                 if (!reader.elementAvailable()) {
                     buffer.position(mark);
-                    // We need to create a duplicate because buffer will be closed by the reader (try-with-resources)
-                    return ctx.getStopAction(buffer.duplicate());
+                    // We need to split because buffer will be closed by the reader (try-with-resources)
+                    return ctx.getStopAction(buffer.split(0));
                 }
                 final int length = reader.peekLength();
                 if (length > maxASN1ElementSize) {


### PR DESCRIPTION
This fixes ASN.1 parsing error that was caused by reusing buffer array shared by a disposed `ByteBuffer` and its duplicate `ByteBuffer`. I did try to write unit test for this but it was almost impossible to write it in a way that was worth adding to the project.


```
Caused by: org.forgerock.opendj.ldap.DecodeException: Cannot decode the provided ASN.1 integer element because the length of the element value was not between one and four bytes (actual length was 32)
	at org.forgerock.opendj.ldap.DecodeException.fatalError(DecodeException.java:66)
	at org.forgerock.opendj.grizzly.ASN1BufferReader.readInteger(ASN1BufferReader.java:288)
	at org.forgerock.opendj.io.LDAPReader.readMessage(LDAPReader.java:121)
	at org.forgerock.opendj.grizzly.LDAPClientFilter.handleRead(LDAPClientFilter.java:438)
	... 14 more
```
