### PR TITLE
Ignore push event on dependabot branches

### DIFF
--- a/.github/workflows/build-project.yml
+++ b/.github/workflows/build-project.yml
@@ -1,6 +1,10 @@
 name: Build
 
-on: [push, pull_request]
+on:
+  push:
+    branches-ignore:
+      - 'dependabot/**'
+  pull_request:
 
 jobs:
   build:


### PR DESCRIPTION
Dependabot creates a branch and a PR. Actions will be triggered for both without this change.