### PR TITLE
Additional test fixes when run with limited resources

### DIFF
--- a/opendj-server-legacy/src/test/java/org/opends/server/replication/SchemaReplicationTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/replication/SchemaReplicationTest.java
@@ -234,6 +234,7 @@ public class SchemaReplicationTest extends ReplicationTestCase
         @Override
         public void call() throws Exception
         {
+          Assertions.assertThat(schemaFile).exists();
           String fileStr = readAsString(schemaFile);
           assertTrue(fileStr.contains(stateStr), "The Schema persistentState (CSN:" + stateStr
               + ") has not been saved to " + schemaFile + " : " + fileStr);

--- a/opendj-server-legacy/src/test/java/org/opends/server/replication/server/AssuredReplicationServerTest.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/replication/server/AssuredReplicationServerTest.java
@@ -1188,8 +1188,27 @@ public class AssuredReplicationServerTest
           false, AssuredMode.SAFE_DATA_MODE, 1, TIMEOUT_RS_SCENARIO);
       }
 
-      // Send update from DS 1
+      // Wait for topology to fully propagate so the RS knows every peer's group ID
+      // before fakeRd1 publishes — otherwise the RS may forward the first update
+      // with a stale assured flag, which the receiver counts as a "wrong" update.
       final FakeReplicationDomain fakeRd1 = fakeRDs[1];
+      TestCaseUtils.repeatUntilSuccess(() -> {
+        if (otherFakeDS)
+        {
+          DSInfo info = fakeRd1.getReplicaInfos().get(FDS2_ID);
+          assertNotNull(info, "fakeRd1 does not yet see FDS2 in its topology");
+          assertEquals(info.getGroupId(), (byte) otherFakeDsGid);
+        }
+        if (fakeRS)
+        {
+          RSInfo rsInfo = fakeRd1.getRsInfos().stream()
+              .filter(r -> r.getId() == FRS1_ID).findFirst().orElse(null);
+          assertNotNull(rsInfo, "fakeRd1 does not yet see fakeRs1 in its topology");
+          assertEquals(rsInfo.getGroupId(), (byte) fakeRsGid);
+        }
+      });
+
+      // Send update from DS 1
       long startTime = System.currentTimeMillis();
       fakeRd1.sendNewFakeUpdate();
 


### PR DESCRIPTION
There are still occasional test failures when run under GH Actions that I am not able to replicate locally (see failed _Actions_ history).