### PR TITLE
Update wrensec-commons to fix HTTPConnectionHandler issues

### DIFF
--- a/opendj-server-legacy/src/test/java/org/opends/server/protocols/jmx/JmxTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/protocols/jmx/JmxTestCase.java
@@ -106,14 +106,19 @@ public abstract class JmxTestCase extends DirectoryServerTestCase
 
   private void enableJmx() throws Exception
   {
-    ModifyOperationBasis op = new ModifyOperationBasis(
-        getRootConnection(), nextOperationID(), nextMessageID(), null,
-        DN.valueOf("cn=JMX Connection Handler,cn=Connection Handlers,cn=config"),
-        newArrayList(new Modification(REPLACE, Attributes.create("ds-cfg-enabled", "true"))));
-    op.run();
-    Assertions.assertThat(op.getResultCode())
-      .withFailMessage("Failed to enable JMX connection handler: %s - %s",
-                       op.getResultCode(), op.getErrorMessage())
-      .isEqualTo(ResultCode.SUCCESS);
+    TestCaseUtils.repeatUntilSuccess(() -> {
+      int port = TestCaseUtils.findFreePort();
+      ModifyOperationBasis op = new ModifyOperationBasis(
+          getRootConnection(), nextOperationID(), nextMessageID(), null,
+          DN.valueOf("cn=JMX Connection Handler,cn=Connection Handlers,cn=config"),
+          newArrayList(
+              new Modification(REPLACE, Attributes.create("ds-cfg-listen-port", String.valueOf(port))),
+              new Modification(REPLACE, Attributes.create("ds-cfg-enabled", "true"))));
+      op.run();
+      Assertions.assertThat(op.getResultCode())
+          .withFailMessage("Failed to enable JMX connection handler: %s - %s",
+              op.getResultCode(), op.getErrorMessage())
+          .isEqualTo(ResultCode.SUCCESS);
+    });
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,7 @@
 
         <bouncycastle.version>1.83</bouncycastle.version>
         <freemarker.version>2.3.34</freemarker.version>
-        <wrensec-commons.version>23.0.0</wrensec-commons.version>
+        <wrensec-commons.version>23.0.2</wrensec-commons.version>
 
         <opendj.osgi.import.additional />
         <opendj.osgi.import>


### PR DESCRIPTION
Updating to the latest Wrensec Commons to get WrenSecurity/wrensec-commons#93.