### PR TITLE
Add PBKDF2-HMAC-SHA256 and PBKDF2-HMAC-SHA512 password encoding schemes

### DIFF
--- a/opendj-doc-generated-ref/src/main/docbkx/man-pages/encode-password-examples.xml
+++ b/opendj-doc-generated-ref/src/main/docbkx/man-pages/encode-password-examples.xml
@@ -13,6 +13,7 @@
   information: "Portions Copyright [year] [name of copyright owner]".
 
   Copyright 2015-2016 ForgeRock AS.
+  Portions Copyright 2026 Wren Security
 -->
 <refsect1 xmlns="http://docbook.org/ns/docbook"
           version="5.0" xml:lang="en"
@@ -38,6 +39,8 @@ CLEAR
 CRYPT
 MD5
 PBKDF2
+PBKDF2-HMAC-SHA256
+PBKDF2-HMAC-SHA512
 PKCS5S2
 RC4
 SHA

--- a/opendj-maven-plugin/src/main/resources/config/xml/org/forgerock/opendj/server/config/PBKDF2HmacSHA256PasswordStorageSchemeConfiguration.xml
+++ b/opendj-maven-plugin/src/main/resources/config/xml/org/forgerock/opendj/server/config/PBKDF2HmacSHA256PasswordStorageSchemeConfiguration.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    The contents of this file are subject to the terms of the Common Development and
+    Distribution License (the License). You may not use this file except in compliance with the
+    License.
+
+    You can obtain a copy of the License at legal/CDDLv1.0.txt. See the License for the
+    specific language governing permission and limitations under the License.
+
+    When distributing Covered Software, include this CDDL Header Notice in each file and include
+    the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
+    Header, with the fields enclosed by brackets [] replaced by your own identifying
+    information: "Portions copyright [year] [name of copyright owner]".
+
+    Copyright 2026 Wren Security.
+-->
+<adm:managed-object name="pbkdf2-hmac-sha256-password-storage-scheme"
+  plural-name="pbkdf2-hmac-sha256-password-storage-schemes"
+  package="org.forgerock.opendj.server.config"
+  extends="password-storage-scheme"
+  xmlns:adm="http://opendj.forgerock.org/admin"
+  xmlns:ldap="http://opendj.forgerock.org/admin-ldap">
+  <adm:synopsis>
+    The
+    <adm:user-friendly-name />
+    provides a mechanism for encoding user passwords using the PBKDF2
+    key derivation function with HMAC-SHA256 as its pseudo-random function.
+  </adm:synopsis>
+  <adm:description>
+    This scheme contains an implementation for the user password syntax,
+    with a storage scheme name of "PBKDF2-HMAC-SHA256".
+  </adm:description>
+  <adm:profile name="ldap">
+    <ldap:object-class>
+      <ldap:name>ds-cfg-pbkdf2-hmac-sha256-password-storage-scheme</ldap:name>
+      <ldap:superior>ds-cfg-password-storage-scheme</ldap:superior>
+    </ldap:object-class>
+  </adm:profile>
+  <adm:property-override name="java-class" advanced="true">
+    <adm:default-behavior>
+      <adm:defined>
+        <adm:value>
+          org.opends.server.extensions.PBKDF2HmacSHA256PasswordStorageScheme
+        </adm:value>
+      </adm:defined>
+    </adm:default-behavior>
+  </adm:property-override>
+  <adm:property name="pbkdf2-iterations" advanced="false">
+    <adm:synopsis>
+      The number of algorithm iterations to make. Increasing this value
+      strengthens stored passwords against offline attacks, but adds CPU
+      cost to every password comparison, including every bind. The
+      default is the iteration count recommended for
+      PBKDF2-HMAC-SHA256 by the OWASP Password Storage Cheat Sheet,
+      which raises its recommended counts over time as hardware gets
+      faster.
+    </adm:synopsis>
+    <adm:default-behavior>
+      <adm:defined>
+        <adm:value>600000</adm:value>
+      </adm:defined>
+    </adm:default-behavior>
+    <adm:syntax>
+      <adm:integer lower-limit="1" />
+    </adm:syntax>
+    <adm:profile name="ldap">
+      <ldap:attribute>
+        <ldap:name>ds-cfg-pbkdf2-iterations</ldap:name>
+      </ldap:attribute>
+    </adm:profile>
+  </adm:property>
+</adm:managed-object>

--- a/opendj-maven-plugin/src/main/resources/config/xml/org/forgerock/opendj/server/config/PBKDF2HmacSHA512PasswordStorageSchemeConfiguration.xml
+++ b/opendj-maven-plugin/src/main/resources/config/xml/org/forgerock/opendj/server/config/PBKDF2HmacSHA512PasswordStorageSchemeConfiguration.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    The contents of this file are subject to the terms of the Common Development and
+    Distribution License (the License). You may not use this file except in compliance with the
+    License.
+
+    You can obtain a copy of the License at legal/CDDLv1.0.txt. See the License for the
+    specific language governing permission and limitations under the License.
+
+    When distributing Covered Software, include this CDDL Header Notice in each file and include
+    the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
+    Header, with the fields enclosed by brackets [] replaced by your own identifying
+    information: "Portions copyright [year] [name of copyright owner]".
+
+    Copyright 2026 Wren Security.
+-->
+<adm:managed-object name="pbkdf2-hmac-sha512-password-storage-scheme"
+  plural-name="pbkdf2-hmac-sha512-password-storage-schemes"
+  package="org.forgerock.opendj.server.config"
+  extends="password-storage-scheme"
+  xmlns:adm="http://opendj.forgerock.org/admin"
+  xmlns:ldap="http://opendj.forgerock.org/admin-ldap">
+  <adm:synopsis>
+    The
+    <adm:user-friendly-name />
+    provides a mechanism for encoding user passwords using the PBKDF2
+    key derivation function with HMAC-SHA512 as its pseudo-random function.
+  </adm:synopsis>
+  <adm:description>
+    This scheme contains an implementation for the user password syntax,
+    with a storage scheme name of "PBKDF2-HMAC-SHA512".
+  </adm:description>
+  <adm:profile name="ldap">
+    <ldap:object-class>
+      <ldap:name>ds-cfg-pbkdf2-hmac-sha512-password-storage-scheme</ldap:name>
+      <ldap:superior>ds-cfg-password-storage-scheme</ldap:superior>
+    </ldap:object-class>
+  </adm:profile>
+  <adm:property-override name="java-class" advanced="true">
+    <adm:default-behavior>
+      <adm:defined>
+        <adm:value>
+          org.opends.server.extensions.PBKDF2HmacSHA512PasswordStorageScheme
+        </adm:value>
+      </adm:defined>
+    </adm:default-behavior>
+  </adm:property-override>
+  <adm:property name="pbkdf2-iterations" advanced="false">
+    <adm:synopsis>
+      The number of algorithm iterations to make. Increasing this value
+      strengthens stored passwords against offline attacks, but adds CPU
+      cost to every password comparison, including every bind. The
+      default is the iteration count recommended for
+      PBKDF2-HMAC-SHA512 by the OWASP Password Storage Cheat Sheet,
+      which raises its recommended counts over time as hardware gets
+      faster.
+    </adm:synopsis>
+    <adm:default-behavior>
+      <adm:defined>
+        <adm:value>220000</adm:value>
+      </adm:defined>
+    </adm:default-behavior>
+    <adm:syntax>
+      <adm:integer lower-limit="1" />
+    </adm:syntax>
+    <adm:profile name="ldap">
+      <ldap:attribute>
+        <ldap:name>ds-cfg-pbkdf2-iterations</ldap:name>
+      </ldap:attribute>
+    </adm:profile>
+  </adm:property>
+</adm:managed-object>

--- a/opendj-server-legacy/resource/config/config.ldif
+++ b/opendj-server-legacy/resource/config/config.ldif
@@ -14,6 +14,7 @@
 # Portions Copyright 2012-2014 Manuel Gaupp
 # Portions Copyright 2010-2016 ForgeRock AS.
 # Portions copyright 2015 Edan Idzerda
+# Portions Copyright 2026 Wren Security
 
 # This file contains the primary Directory Server configuration.  It must not
 # be directly edited while the server is online.  The server configuration
@@ -1125,6 +1126,22 @@ objectClass: ds-cfg-password-storage-scheme
 objectClass: ds-cfg-pkcs5s2-password-storage-scheme
 cn: PKCS5S2
 ds-cfg-java-class: org.opends.server.extensions.PKCS5S2PasswordStorageScheme
+ds-cfg-enabled: true
+
+dn: cn=PBKDF2-HMAC-SHA256,cn=Password Storage Schemes,cn=config
+objectClass: top
+objectClass: ds-cfg-password-storage-scheme
+objectClass: ds-cfg-pbkdf2-hmac-sha256-password-storage-scheme
+cn: PBKDF2-HMAC-SHA256
+ds-cfg-java-class: org.opends.server.extensions.PBKDF2HmacSHA256PasswordStorageScheme
+ds-cfg-enabled: true
+
+dn: cn=PBKDF2-HMAC-SHA512,cn=Password Storage Schemes,cn=config
+objectClass: top
+objectClass: ds-cfg-password-storage-scheme
+objectClass: ds-cfg-pbkdf2-hmac-sha512-password-storage-scheme
+cn: PBKDF2-HMAC-SHA512
+ds-cfg-java-class: org.opends.server.extensions.PBKDF2HmacSHA512PasswordStorageScheme
 ds-cfg-enabled: true
 
 dn: cn=SHA-1,cn=Password Storage Schemes,cn=config

--- a/opendj-server-legacy/resource/schema/02-config.ldif
+++ b/opendj-server-legacy/resource/schema/02-config.ldif
@@ -6220,3 +6220,15 @@ objectClasses: ( 1.3.6.1.4.1.36733.2.1.2.58
         ds-cfg-bind-password $
         ds-cfg-discovery-interval )
   X-ORIGIN 'OpenDJ Directory Server' )
+objectClasses: ( 1.3.6.1.4.1.64165.2.1.2.1
+  NAME 'ds-cfg-pbkdf2-hmac-sha256-password-storage-scheme'
+  SUP ds-cfg-password-storage-scheme
+  STRUCTURAL
+  MAY ds-cfg-pbkdf2-iterations
+  X-ORIGIN 'OpenDJ Directory Server' )
+objectClasses: ( 1.3.6.1.4.1.64165.2.1.2.2
+  NAME 'ds-cfg-pbkdf2-hmac-sha512-password-storage-scheme'
+  SUP ds-cfg-password-storage-scheme
+  STRUCTURAL
+  MAY ds-cfg-pbkdf2-iterations
+  X-ORIGIN 'OpenDJ Directory Server' )

--- a/opendj-server-legacy/src/main/java/org/opends/server/extensions/AbstractPBKDF2PasswordStorageScheme.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/extensions/AbstractPBKDF2PasswordStorageScheme.java
@@ -1,0 +1,294 @@
+/*
+ * The contents of this file are subject to the terms of the Common Development and
+ * Distribution License (the License). You may not use this file except in compliance with the
+ * License.
+ *
+ * You can obtain a copy of the License at legal/CDDLv1.0.txt. See the License for the
+ * specific language governing permission and limitations under the License.
+ *
+ * When distributing Covered Software, include this CDDL Header Notice in each file and include
+ * the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
+ * Header, with the fields enclosed by brackets [] replaced by your own identifying
+ * information: "Portions Copyright [year] [name of copyright owner]".
+ *
+ * Copyright 2013-2016 ForgeRock AS.
+ * Portions Copyright 2026 Wren Security
+ */
+package org.opends.server.extensions;
+
+import static org.opends.messages.ExtensionMessages.ERR_PWSCHEME_CANNOT_BASE64_DECODE_STORED_PASSWORD;
+import static org.opends.messages.ExtensionMessages.ERR_PWSCHEME_CANNOT_ENCODE_PASSWORD;
+import static org.opends.messages.ExtensionMessages.ERR_PWSCHEME_INVALID_BASE64_DECODED_STORED_PASSWORD;
+import static org.opends.messages.ExtensionMessages.ERR_PWSCHEME_NOT_REVERSIBLE;
+import static org.opends.messages.ExtensionMessages.ERR_PWSCHEME_UNSUPPORTED_ALGORITHM;
+import static org.opends.server.extensions.ExtensionsConstants.SECURE_PRNG_SHA1;
+import static org.opends.server.util.StaticUtils.getExceptionMessage;
+
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.security.spec.KeySpec;
+import java.util.Arrays;
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.PBEKeySpec;
+import org.forgerock.i18n.LocalizableMessage;
+import org.forgerock.i18n.slf4j.LocalizedLogger;
+import org.forgerock.opendj.config.server.ConfigException;
+import org.forgerock.opendj.ldap.Base64;
+import org.forgerock.opendj.ldap.ByteSequence;
+import org.forgerock.opendj.ldap.ByteString;
+import org.forgerock.opendj.ldap.ResultCode;
+import org.forgerock.opendj.server.config.server.PasswordStorageSchemeCfg;
+import org.opends.server.api.PasswordStorageScheme;
+import org.opends.server.core.DirectoryServer;
+import org.opends.server.types.DirectoryException;
+import org.opends.server.types.InitializationException;
+
+/**
+ * Common implementation of the Directory Server password storage schemes based
+ * on the PBKDF2 algorithm defined in RFC 2898. This is a one-way digest
+ * algorithm so there is no way to retrieve the original clear-text version of
+ * the password from the hashed value (although this means that it is not
+ * suitable for things that need the clear-text password like DIGEST-MD5).
+ * <p>
+ * Passwords are stored as the number of iterations, followed by a colon,
+ * followed by the base64 encoding of the derived key concatenated with the
+ * salt. Concrete subclasses only need to name the underlying pseudo-random
+ * function and the length of the digest it produces, together with the
+ * configured number of iterations.
+ *
+ * @param <T> The type of the configuration of the concrete storage scheme.
+ */
+abstract class AbstractPBKDF2PasswordStorageScheme<T extends PasswordStorageSchemeCfg> extends PasswordStorageScheme<T> {
+
+    private static final LocalizedLogger logger = LocalizedLogger.getLoggerForThisClass();
+
+    /**
+     * The number of bytes of random data to use as the salt when generating the
+     * hashes. NIST SP 800-132 requires at least 128 bits of randomly generated salt
+     * for PBKDF2.
+     */
+    private static final int NUM_SALT_BYTES = 16;
+
+    /**
+     * The secure random number generator to use to generate the salt values.
+     */
+    private SecureRandom random;
+
+    /**
+     * Returns the name of the JCE secret key factory algorithm implementing the
+     * pseudo-random function of this scheme.
+     *
+     * @return The name of the JCE secret key factory algorithm.
+     */
+    abstract String getSecretKeyFactoryAlgorithm();
+
+    /**
+     * Returns the number of bytes produced by the pseudo-random function of this
+     * scheme, which is also the length of the derived key that is stored.
+     *
+     * @return The number of bytes of the derived key.
+     */
+    abstract int getDigestLengthBytes();
+
+    /**
+     * Returns the number of algorithm iterations to make, as currently configured,
+     * or the default of this scheme when it has not been configured, which is the
+     * case when encoding a password with the server offline.
+     *
+     * @return The number of algorithm iterations to make.
+     */
+    abstract int getIterations();
+
+    /**
+     * Initializes the state shared by all PBKDF2 based storage schemes. Concrete
+     * subclasses must call this from their {@code initializePasswordStorageScheme}
+     * implementation before registering their configuration change listener.
+     *
+     * @throws ConfigException If a configuration problem prevents initialization.
+     * @throws InitializationException If the algorithm of this scheme is not supported.
+     */
+    final void initializeScheme() throws ConfigException, InitializationException {
+        try {
+            random = SecureRandom.getInstance(SECURE_PRNG_SHA1);
+            // Just try to verify if the algorithm is supported.
+            SecretKeyFactory.getInstance(getSecretKeyFactoryAlgorithm());
+        } catch (NoSuchAlgorithmException e) {
+            logger.traceException(e);
+            throw new InitializationException(ERR_PWSCHEME_UNSUPPORTED_ALGORITHM.get(getStorageSchemeName(), e), e);
+        }
+    }
+
+    @Override
+    public ByteString encodePassword(ByteSequence plaintext) throws DirectoryException {
+        byte[] saltBytes = new byte[NUM_SALT_BYTES];
+        int iterations = getIterations();
+
+        byte[] digestBytes = encodeWithRandomSalt(plaintext, saltBytes, iterations, random);
+        byte[] hashPlusSalt = concatenateHashPlusSalt(saltBytes, digestBytes);
+
+        return ByteString.valueOfUtf8(iterations + ":" + Base64.encode(hashPlusSalt));
+    }
+
+    @Override
+    public ByteString encodePasswordWithScheme(ByteSequence plaintext) throws DirectoryException {
+        return ByteString.valueOfUtf8('{' + getStorageSchemeName() + '}' + encodePassword(plaintext));
+    }
+
+    @Override
+    public boolean passwordMatches(ByteSequence plaintextPassword, ByteSequence storedPassword) {
+        // Split the iterations from the stored value (separated by a ':')
+        // Base64-decode the remaining value and take the trailing bytes as the salt.
+        try {
+            final String stored = storedPassword.toString();
+            final int pos = stored.indexOf(':');
+            if (pos == -1) {
+                throw new Exception();
+            }
+
+            final int digestLength = getDigestLengthBytes();
+            final int iterations = Integer.parseInt(stored.substring(0, pos));
+            final byte[] decodedBytes = Base64.decode(stored.substring(pos + 1)).toByteArray();
+
+            final int saltLength = decodedBytes.length - digestLength;
+            if (saltLength <= 0) {
+                logger.error(ERR_PWSCHEME_INVALID_BASE64_DECODED_STORED_PASSWORD, storedPassword);
+                return false;
+            }
+
+            final byte[] digestBytes = new byte[digestLength];
+            final byte[] saltBytes = new byte[saltLength];
+            System.arraycopy(decodedBytes, 0, digestBytes, 0, digestLength);
+            System.arraycopy(decodedBytes, digestLength, saltBytes, 0, saltLength);
+            return encodeAndMatch(plaintextPassword, saltBytes, digestBytes, iterations);
+        } catch (Exception e) {
+            logger.traceException(e);
+            logger.error(ERR_PWSCHEME_CANNOT_BASE64_DECODE_STORED_PASSWORD, storedPassword, e);
+            return false;
+        }
+    }
+
+    @Override
+    public boolean supportsAuthPasswordSyntax() {
+        return true;
+    }
+
+    @Override
+    public ByteString encodeAuthPassword(ByteSequence plaintext) throws DirectoryException {
+        byte[] saltBytes = new byte[NUM_SALT_BYTES];
+        int iterations = getIterations();
+        byte[] digestBytes = encodeWithRandomSalt(plaintext, saltBytes, iterations, random);
+
+        // Encode and return the value.
+        return ByteString.valueOfUtf8(getAuthPasswordSchemeName() + '$' + iterations + ':' + Base64.encode(saltBytes)
+                + '$' + Base64.encode(digestBytes));
+    }
+
+    @Override
+    public boolean authPasswordMatches(ByteSequence plaintextPassword, String authInfo, String authValue) {
+        try {
+            int pos = authInfo.indexOf(':');
+            if (pos == -1) {
+                throw new Exception();
+            }
+            int iterations = Integer.parseInt(authInfo.substring(0, pos));
+            byte[] saltBytes = Base64.decode(authInfo.substring(pos + 1)).toByteArray();
+            byte[] digestBytes = Base64.decode(authValue).toByteArray();
+            return encodeAndMatch(plaintextPassword, saltBytes, digestBytes, iterations);
+        } catch (Exception e) {
+            logger.traceException(e);
+            return false;
+        }
+    }
+
+    @Override
+    public boolean isReversible() {
+        return false;
+    }
+
+    @Override
+    public ByteString getPlaintextValue(ByteSequence storedPassword) throws DirectoryException {
+        LocalizableMessage message = ERR_PWSCHEME_NOT_REVERSIBLE.get(getStorageSchemeName());
+        throw new DirectoryException(ResultCode.CONSTRAINT_VIOLATION, message);
+    }
+
+    @Override
+    public ByteString getAuthPasswordPlaintextValue(String authInfo, String authValue) throws DirectoryException {
+        LocalizableMessage message = ERR_PWSCHEME_NOT_REVERSIBLE.get(getAuthPasswordSchemeName());
+        throw new DirectoryException(ResultCode.CONSTRAINT_VIOLATION, message);
+    }
+
+    @Override
+    public boolean isStorageSchemeSecure() {
+        return true;
+    }
+
+    /**
+     * Generates an encoded password string from the given clear-text password using
+     * a fixed number of iterations. This is intended for use by the
+     * {@code encodeOffline} method of the concrete schemes, which is used when it is
+     * necessary to generate a password with the server offline (e.g., when setting
+     * the initial root user password), and therefore must not depend on the
+     * configuration of this scheme.
+     *
+     * @param passwordBytes The bytes that make up the clear-text password.
+     * @return The encoded password string, including the scheme name in curly braces.
+     * @throws DirectoryException If a problem occurs during processing.
+     */
+    String encodePasswordOffline(byte[] passwordBytes) throws DirectoryException {
+        final byte[] saltBytes = new byte[NUM_SALT_BYTES];
+        final ByteString password = ByteString.wrap(passwordBytes);
+        final int iterations = getIterations();
+
+        final byte[] digestBytes;
+        try {
+            digestBytes = encodeWithRandomSalt(password, saltBytes, iterations,
+                    SecureRandom.getInstance(SECURE_PRNG_SHA1));
+        } catch (NoSuchAlgorithmException e) {
+            throw cannotEncodePassword(e);
+        }
+        final byte[] hashPlusSalt = concatenateHashPlusSalt(saltBytes, digestBytes);
+        return '{' + getStorageSchemeName() + '}' + iterations + ':' + Base64.encode(hashPlusSalt);
+    }
+
+    private boolean encodeAndMatch(ByteSequence plaintext, byte[] saltBytes, byte[] digestBytes, int iterations) {
+        try {
+            final byte[] userDigestBytes = encodeWithSalt(plaintext, saltBytes, iterations);
+            return Arrays.equals(digestBytes, userDigestBytes);
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    private byte[] encodeWithRandomSalt(ByteSequence plaintext, byte[] saltBytes, int iterations, SecureRandom random)
+            throws DirectoryException {
+        random.nextBytes(saltBytes);
+        return encodeWithSalt(plaintext, saltBytes, iterations);
+    }
+
+    private byte[] encodeWithSalt(ByteSequence plaintext, byte[] saltBytes, int iterations) throws DirectoryException {
+        final char[] plaintextChars = plaintext.toString().toCharArray();
+        try {
+            final SecretKeyFactory factory = SecretKeyFactory.getInstance(getSecretKeyFactoryAlgorithm());
+            final KeySpec spec = new PBEKeySpec(plaintextChars, saltBytes, iterations, getDigestLengthBytes() * 8);
+            return factory.generateSecret(spec).getEncoded();
+        } catch (Exception e) {
+            throw cannotEncodePassword(e);
+        } finally {
+            Arrays.fill(plaintextChars, '0');
+        }
+    }
+
+    private DirectoryException cannotEncodePassword(Exception e) {
+        logger.traceException(e);
+        LocalizableMessage message = ERR_PWSCHEME_CANNOT_ENCODE_PASSWORD.get(getClass().getName(), getExceptionMessage(e));
+        return new DirectoryException(DirectoryServer.getCoreConfigManager().getServerErrorResultCode(), message, e);
+    }
+
+    private static byte[] concatenateHashPlusSalt(byte[] saltBytes, byte[] digestBytes) {
+        final byte[] hashPlusSalt = new byte[digestBytes.length + NUM_SALT_BYTES];
+        System.arraycopy(digestBytes, 0, hashPlusSalt, 0, digestBytes.length);
+        System.arraycopy(saltBytes, 0, hashPlusSalt, digestBytes.length, NUM_SALT_BYTES);
+        return hashPlusSalt;
+    }
+
+}

--- a/opendj-server-legacy/src/main/java/org/opends/server/extensions/ExtensionsConstants.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/extensions/ExtensionsConstants.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2006-2008 Sun Microsystems, Inc.
  * Portions copyright 2013-2016 ForgeRock AS.
+ * Portions Copyright 2026 Wren Security
  */
 package org.opends.server.extensions;
 
@@ -81,6 +82,22 @@ public class ExtensionsConstants
   public static final String AUTH_PASSWORD_SCHEME_NAME_PKCS5S2 = "PKCS5S2";
 
 
+
+  /**
+   * The authentication password scheme name for use with passwords encoded in a
+   * PBKDF2-HMAC-SHA256 representation.
+   */
+  public static final String AUTH_PASSWORD_SCHEME_NAME_PBKDF2_HMAC_SHA256 = "PBKDF2-HMAC-SHA256";
+
+
+
+  /**
+   * The authentication password scheme name for use with passwords encoded in a
+   * PBKDF2-HMAC-SHA512 representation.
+   */
+  public static final String AUTH_PASSWORD_SCHEME_NAME_PBKDF2_HMAC_SHA512 = "PBKDF2-HMAC-SHA512";
+
+
   /**
    * The name of the message digest algorithm that should be used to generate
    * MD5 hashes.
@@ -122,11 +139,29 @@ public class ExtensionsConstants
 
 
   /**
-   * The name of the message digest algorithm that should be used to generate
-   * PBKDF2 hashes.
+   * The name of the secret key factory algorithm that should be used to
+   * generate PBKDF2-HMAC-SHA1 hashes.
    */
-  public static final String MESSAGE_DIGEST_ALGORITHM_PBKDF2 =
+  public static final String SECRET_KEY_FACTORY_ALGORITHM_PBKDF2 =
        "PBKDF2WithHmacSHA1";
+
+
+
+  /**
+   * The name of the secret key factory algorithm that should be used to
+   * generate PBKDF2-HMAC-SHA256 hashes.
+   */
+  public static final String SECRET_KEY_FACTORY_ALGORITHM_PBKDF2_SHA256 =
+       "PBKDF2WithHmacSHA256";
+
+
+
+  /**
+   * The name of the secret key factory algorithm that should be used to
+   * generate PBKDF2-HMAC-SHA512 hashes.
+   */
+  public static final String SECRET_KEY_FACTORY_ALGORITHM_PBKDF2_SHA512 =
+       "PBKDF2WithHmacSHA512";
 
 
 
@@ -334,6 +369,22 @@ public class ExtensionsConstants
    * a PKCS5S2 representation.
    */
   public static final String STORAGE_SCHEME_NAME_PKCS5S2 = "PKCS5S2";
+
+
+
+  /**
+   * The password storage scheme name that will be used for passwords stored in
+   * a PBKDF2-HMAC-SHA256 representation.
+   */
+  public static final String STORAGE_SCHEME_NAME_PBKDF2_HMAC_SHA256 = "PBKDF2-HMAC-SHA256";
+
+
+
+  /**
+   * The password storage scheme name that will be used for passwords stored in
+   * a PBKDF2-HMAC-SHA512 representation.
+   */
+  public static final String STORAGE_SCHEME_NAME_PBKDF2_HMAC_SHA512 = "PBKDF2-HMAC-SHA512";
 
 
 

--- a/opendj-server-legacy/src/main/java/org/opends/server/extensions/PBKDF2HmacSHA256PasswordStorageScheme.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/extensions/PBKDF2HmacSHA256PasswordStorageScheme.java
@@ -11,82 +11,80 @@
  * Header, with the fields enclosed by brackets [] replaced by your own identifying
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
- * Copyright 2013-2016 ForgeRock AS.
- * Portions Copyright 2026 Wren Security
+ * Copyright 2026 Wren Security
  */
 package org.opends.server.extensions;
 
-import static org.opends.server.extensions.ExtensionsConstants.*;
+import static org.opends.server.extensions.ExtensionsConstants.AUTH_PASSWORD_SCHEME_NAME_PBKDF2_HMAC_SHA256;
+import static org.opends.server.extensions.ExtensionsConstants.SECRET_KEY_FACTORY_ALGORITHM_PBKDF2_SHA256;
+import static org.opends.server.extensions.ExtensionsConstants.STORAGE_SCHEME_NAME_PBKDF2_HMAC_SHA256;
 
 import java.util.List;
-
 import org.forgerock.i18n.LocalizableMessage;
 import org.forgerock.opendj.config.server.ConfigChangeResult;
 import org.forgerock.opendj.config.server.ConfigException;
 import org.forgerock.opendj.config.server.ConfigurationChangeListener;
-import org.forgerock.opendj.server.config.server.PBKDF2PasswordStorageSchemeCfg;
+import org.forgerock.opendj.server.config.server.PBKDF2HmacSHA256PasswordStorageSchemeCfg;
 import org.opends.server.types.DirectoryException;
 import org.opends.server.types.InitializationException;
 
 /**
  * This class defines a Directory Server password storage scheme based on the
- * PBKDF2 algorithm defined in RFC 2898, using HMAC-SHA-1 as its pseudo-random
+ * PBKDF2 algorithm defined in RFC 2898, using HMAC-SHA-256 as its pseudo-random
  * function. This is a one-way digest algorithm so there is no way to retrieve
  * the original clear-text version of the password from the hashed value
  * (although this means that it is not suitable for things that need the
  * clear-text password like DIGEST-MD5). This implementation uses a configurable
  * number of iterations.
  */
-public class PBKDF2PasswordStorageScheme
-        extends AbstractPBKDF2PasswordStorageScheme<PBKDF2PasswordStorageSchemeCfg>
-        implements ConfigurationChangeListener<PBKDF2PasswordStorageSchemeCfg> {
+public class PBKDF2HmacSHA256PasswordStorageScheme
+        extends AbstractPBKDF2PasswordStorageScheme<PBKDF2HmacSHA256PasswordStorageSchemeCfg>
+        implements ConfigurationChangeListener<PBKDF2HmacSHA256PasswordStorageSchemeCfg> {
 
-    /** The number of bytes the SHA-1 algorithm produces. */
-    private static final int SHA1_LENGTH = 20;
+    private static final int SHA256_LENGTH = 32;
 
     /** The number of iterations used when this scheme has not been configured. */
-    private static final int DEFAULT_ITERATIONS = 10000;
+    private static final int DEFAULT_ITERATIONS = 600000;
 
-    /** The current configuration for this storage scheme. */
-    private volatile PBKDF2PasswordStorageSchemeCfg config;
+    private volatile PBKDF2HmacSHA256PasswordStorageSchemeCfg config;
 
     /**
      * Creates a new instance of this password storage scheme. Note that no
      * initialization should be performed here, as all initialization should be done
-     * in the <CODE>initializePasswordStorageScheme</CODE> method.
+     * in the <code>initializePasswordStorageScheme</code> method.
      */
-    public PBKDF2PasswordStorageScheme() {
+    public PBKDF2HmacSHA256PasswordStorageScheme() {
     }
 
     @Override
-    public void initializePasswordStorageScheme(PBKDF2PasswordStorageSchemeCfg configuration)
+    public void initializePasswordStorageScheme(PBKDF2HmacSHA256PasswordStorageSchemeCfg configuration)
             throws ConfigException, InitializationException {
         initializeScheme();
 
         this.config = configuration;
-        config.addPBKDF2ChangeListener(this);
+        config.addPBKDF2HmacSHA256ChangeListener(this);
     }
 
     @Override
-    public boolean isConfigurationChangeAcceptable(PBKDF2PasswordStorageSchemeCfg configuration,
+    public boolean isConfigurationChangeAcceptable(PBKDF2HmacSHA256PasswordStorageSchemeCfg configuration,
             List<LocalizableMessage> unacceptableReasons) {
         return true;
     }
 
     @Override
-    public ConfigChangeResult applyConfigurationChange(PBKDF2PasswordStorageSchemeCfg configuration) {
+    public ConfigChangeResult applyConfigurationChange(PBKDF2HmacSHA256PasswordStorageSchemeCfg configuration) {
         this.config = configuration;
         return new ConfigChangeResult();
     }
 
     @Override
     String getSecretKeyFactoryAlgorithm() {
-        return SECRET_KEY_FACTORY_ALGORITHM_PBKDF2;
+        return SECRET_KEY_FACTORY_ALGORITHM_PBKDF2_SHA256;
     }
 
     @Override
     int getDigestLengthBytes() {
-        return SHA1_LENGTH;
+        return SHA256_LENGTH;
     }
 
     @Override
@@ -96,12 +94,12 @@ public class PBKDF2PasswordStorageScheme
 
     @Override
     public String getStorageSchemeName() {
-        return STORAGE_SCHEME_NAME_PBKDF2;
+        return STORAGE_SCHEME_NAME_PBKDF2_HMAC_SHA256;
     }
 
     @Override
     public String getAuthPasswordSchemeName() {
-        return AUTH_PASSWORD_SCHEME_NAME_PBKDF2;
+        return AUTH_PASSWORD_SCHEME_NAME_PBKDF2_HMAC_SHA256;
     }
 
     /**
@@ -111,6 +109,6 @@ public class PBKDF2PasswordStorageScheme
      * @return The encoded password string, including the scheme name in curly braces.
      */
     public static String encodeOffline(byte[] passwordBytes) throws DirectoryException {
-        return new PBKDF2PasswordStorageScheme().encodePasswordOffline(passwordBytes);
+        return new PBKDF2HmacSHA256PasswordStorageScheme().encodePasswordOffline(passwordBytes);
     }
 }

--- a/opendj-server-legacy/src/main/java/org/opends/server/extensions/PBKDF2HmacSHA512PasswordStorageScheme.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/extensions/PBKDF2HmacSHA512PasswordStorageScheme.java
@@ -11,82 +11,80 @@
  * Header, with the fields enclosed by brackets [] replaced by your own identifying
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
- * Copyright 2013-2016 ForgeRock AS.
- * Portions Copyright 2026 Wren Security
+ * Copyright 2026 Wren Security
  */
 package org.opends.server.extensions;
 
-import static org.opends.server.extensions.ExtensionsConstants.*;
+import static org.opends.server.extensions.ExtensionsConstants.AUTH_PASSWORD_SCHEME_NAME_PBKDF2_HMAC_SHA512;
+import static org.opends.server.extensions.ExtensionsConstants.SECRET_KEY_FACTORY_ALGORITHM_PBKDF2_SHA512;
+import static org.opends.server.extensions.ExtensionsConstants.STORAGE_SCHEME_NAME_PBKDF2_HMAC_SHA512;
 
 import java.util.List;
-
 import org.forgerock.i18n.LocalizableMessage;
 import org.forgerock.opendj.config.server.ConfigChangeResult;
 import org.forgerock.opendj.config.server.ConfigException;
 import org.forgerock.opendj.config.server.ConfigurationChangeListener;
-import org.forgerock.opendj.server.config.server.PBKDF2PasswordStorageSchemeCfg;
+import org.forgerock.opendj.server.config.server.PBKDF2HmacSHA512PasswordStorageSchemeCfg;
 import org.opends.server.types.DirectoryException;
 import org.opends.server.types.InitializationException;
 
 /**
  * This class defines a Directory Server password storage scheme based on the
- * PBKDF2 algorithm defined in RFC 2898, using HMAC-SHA-1 as its pseudo-random
+ * PBKDF2 algorithm defined in RFC 2898, using HMAC-SHA-512 as its pseudo-random
  * function. This is a one-way digest algorithm so there is no way to retrieve
  * the original clear-text version of the password from the hashed value
  * (although this means that it is not suitable for things that need the
  * clear-text password like DIGEST-MD5). This implementation uses a configurable
  * number of iterations.
  */
-public class PBKDF2PasswordStorageScheme
-        extends AbstractPBKDF2PasswordStorageScheme<PBKDF2PasswordStorageSchemeCfg>
-        implements ConfigurationChangeListener<PBKDF2PasswordStorageSchemeCfg> {
+public class PBKDF2HmacSHA512PasswordStorageScheme
+        extends AbstractPBKDF2PasswordStorageScheme<PBKDF2HmacSHA512PasswordStorageSchemeCfg>
+        implements ConfigurationChangeListener<PBKDF2HmacSHA512PasswordStorageSchemeCfg> {
 
-    /** The number of bytes the SHA-1 algorithm produces. */
-    private static final int SHA1_LENGTH = 20;
+    private static final int SHA512_LENGTH = 64;
 
     /** The number of iterations used when this scheme has not been configured. */
-    private static final int DEFAULT_ITERATIONS = 10000;
+    private static final int DEFAULT_ITERATIONS = 220000;
 
-    /** The current configuration for this storage scheme. */
-    private volatile PBKDF2PasswordStorageSchemeCfg config;
+    private volatile PBKDF2HmacSHA512PasswordStorageSchemeCfg config;
 
     /**
      * Creates a new instance of this password storage scheme. Note that no
      * initialization should be performed here, as all initialization should be done
-     * in the <CODE>initializePasswordStorageScheme</CODE> method.
+     * in the <code>initializePasswordStorageScheme</code> method.
      */
-    public PBKDF2PasswordStorageScheme() {
+    public PBKDF2HmacSHA512PasswordStorageScheme() {
     }
 
     @Override
-    public void initializePasswordStorageScheme(PBKDF2PasswordStorageSchemeCfg configuration)
+    public void initializePasswordStorageScheme(PBKDF2HmacSHA512PasswordStorageSchemeCfg configuration)
             throws ConfigException, InitializationException {
         initializeScheme();
 
         this.config = configuration;
-        config.addPBKDF2ChangeListener(this);
+        config.addPBKDF2HmacSHA512ChangeListener(this);
     }
 
     @Override
-    public boolean isConfigurationChangeAcceptable(PBKDF2PasswordStorageSchemeCfg configuration,
+    public boolean isConfigurationChangeAcceptable(PBKDF2HmacSHA512PasswordStorageSchemeCfg configuration,
             List<LocalizableMessage> unacceptableReasons) {
         return true;
     }
 
     @Override
-    public ConfigChangeResult applyConfigurationChange(PBKDF2PasswordStorageSchemeCfg configuration) {
+    public ConfigChangeResult applyConfigurationChange(PBKDF2HmacSHA512PasswordStorageSchemeCfg configuration) {
         this.config = configuration;
         return new ConfigChangeResult();
     }
 
     @Override
     String getSecretKeyFactoryAlgorithm() {
-        return SECRET_KEY_FACTORY_ALGORITHM_PBKDF2;
+        return SECRET_KEY_FACTORY_ALGORITHM_PBKDF2_SHA512;
     }
 
     @Override
     int getDigestLengthBytes() {
-        return SHA1_LENGTH;
+        return SHA512_LENGTH;
     }
 
     @Override
@@ -96,12 +94,12 @@ public class PBKDF2PasswordStorageScheme
 
     @Override
     public String getStorageSchemeName() {
-        return STORAGE_SCHEME_NAME_PBKDF2;
+        return STORAGE_SCHEME_NAME_PBKDF2_HMAC_SHA512;
     }
 
     @Override
     public String getAuthPasswordSchemeName() {
-        return AUTH_PASSWORD_SCHEME_NAME_PBKDF2;
+        return AUTH_PASSWORD_SCHEME_NAME_PBKDF2_HMAC_SHA512;
     }
 
     /**
@@ -111,6 +109,6 @@ public class PBKDF2PasswordStorageScheme
      * @return The encoded password string, including the scheme name in curly braces.
      */
     public static String encodeOffline(byte[] passwordBytes) throws DirectoryException {
-        return new PBKDF2PasswordStorageScheme().encodePasswordOffline(passwordBytes);
+        return new PBKDF2HmacSHA512PasswordStorageScheme().encodePasswordOffline(passwordBytes);
     }
 }

--- a/opendj-server-legacy/src/main/java/org/opends/server/extensions/PKCS5S2PasswordStorageScheme.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/extensions/PKCS5S2PasswordStorageScheme.java
@@ -87,7 +87,7 @@ public class PKCS5S2PasswordStorageScheme
     {
       random = SecureRandom.getInstance(SECURE_PRNG_SHA1);
       // Just try to verify if the algorithm is supported
-      SecretKeyFactory.getInstance(MESSAGE_DIGEST_ALGORITHM_PBKDF2);
+      SecretKeyFactory.getInstance(SECRET_KEY_FACTORY_ALGORITHM_PBKDF2);
     }
     catch (NoSuchAlgorithmException e)
     {
@@ -265,7 +265,7 @@ public class PKCS5S2PasswordStorageScheme
     final char[] plaintextChars = plaintext.toString().toCharArray();
     try
     {
-      final SecretKeyFactory factory = SecretKeyFactory.getInstance(MESSAGE_DIGEST_ALGORITHM_PBKDF2);
+      final SecretKeyFactory factory = SecretKeyFactory.getInstance(SECRET_KEY_FACTORY_ALGORITHM_PBKDF2);
       KeySpec spec = new PBEKeySpec(plaintextChars, saltBytes, iterations, SHA1_LENGTH * 8);
       return factory.generateSecret(spec).getEncoded();
     }

--- a/opendj-server-legacy/src/main/java/org/opends/server/tools/upgrade/Upgrade.java
+++ b/opendj-server-legacy/src/main/java/org/opends/server/tools/upgrade/Upgrade.java
@@ -549,6 +549,28 @@ public final class Upgrade
 
     register("5.0.4", removeMatchingJarFiles("forgerock-guava-*.jar"));
 
+    register("5.1.2",
+        addConfigEntry(INFO_UPGRADE_TASK_PBKDF2_HMAC_SHA256_SCHEME_SUMMARY.get(),
+            "dn: cn=PBKDF2-HMAC-SHA256,cn=Password Storage Schemes,cn=config",
+            "changetype: add",
+            "objectClass: top",
+            "objectClass: ds-cfg-password-storage-scheme",
+            "objectClass: ds-cfg-pbkdf2-hmac-sha256-password-storage-scheme",
+            "cn: PBKDF2-HMAC-SHA256",
+            "ds-cfg-java-class: org.opends.server.extensions.PBKDF2HmacSHA256PasswordStorageScheme",
+            "ds-cfg-enabled: true"));
+
+    register("5.1.2",
+        addConfigEntry(INFO_UPGRADE_TASK_PBKDF2_HMAC_SHA512_SCHEME_SUMMARY.get(),
+            "dn: cn=PBKDF2-HMAC-SHA512,cn=Password Storage Schemes,cn=config",
+            "changetype: add",
+            "objectClass: top",
+            "objectClass: ds-cfg-password-storage-scheme",
+            "objectClass: ds-cfg-pbkdf2-hmac-sha512-password-storage-scheme",
+            "cn: PBKDF2-HMAC-SHA512",
+            "ds-cfg-java-class: org.opends.server.extensions.PBKDF2HmacSHA512PasswordStorageScheme",
+            "ds-cfg-enabled: true"));
+
     /* All upgrades will refresh the server configuration schema and generate a new upgrade folder. */
     registerLast(
         copySchemaFile("02-config.ldif"),

--- a/opendj-server-legacy/src/messages/org/opends/messages/extension.properties
+++ b/opendj-server-legacy/src/messages/org/opends/messages/extension.properties
@@ -1000,3 +1000,5 @@ ERR_LDAP_TRUSTMANAGER_PIN_FILE_EMPTY_651=File %s specified in \
  attribute ds-cfg-trust-store-pin-file of configuration entry %s should \
  contain the PIN needed to access the LDAP trust manager, but this file \
  is empty
+ERR_PWSCHEME_UNSUPPORTED_ALGORITHM_652=The %s password storage scheme \
+ cannot be initialized because it is not supported by the JVM: %s

--- a/opendj-server-legacy/src/messages/org/opends/messages/tool.properties
+++ b/opendj-server-legacy/src/messages/org/opends/messages/tool.properties
@@ -2526,6 +2526,8 @@ INFO_UPGRADE_TASK_ADDING_DEFAULT_HTTP_ENDPOINTS_AND_AUTH_10075=Adding default HT
 INFO_UPGRADE_TASK_REMOVE_MATCHING_RULES_ENTRY_10076=Removing top configuration entry for matching rules
 INFO_UPGRADE_TASK_REMOVE_SYNTAXES_10077=Removing configuration for syntaxes
 INFO_UPGRADE_TASK_ADD_SCHEMA_PROVIDERS_10078=Adding configuration for schema providers
+INFO_UPGRADE_TASK_PBKDF2_HMAC_SHA256_SCHEME_SUMMARY_10079=Adding PBKDF2-HMAC-SHA256 password storage scheme configuration
+INFO_UPGRADE_TASK_PBKDF2_HMAC_SHA512_SCHEME_SUMMARY_10080=Adding PBKDF2-HMAC-SHA512 password storage scheme configuration
 
 # Strings for generated reference documentation.
 REF_SHORT_DESC_BACKUP_15000=back up OpenDJ directory data

--- a/opendj-server-legacy/src/test/java/org/opends/server/extensions/PBKDF2HmacSHA256PasswordStorageSchemeTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/extensions/PBKDF2HmacSHA256PasswordStorageSchemeTestCase.java
@@ -1,0 +1,75 @@
+/*
+ * The contents of this file are subject to the terms of the Common Development and
+ * Distribution License (the License). You may not use this file except in compliance with the
+ * License.
+ *
+ * You can obtain a copy of the License at legal/CDDLv1.0.txt. See the License for the
+ * specific language governing permission and limitations under the License.
+ *
+ * When distributing Covered Software, include this CDDL Header Notice in each file and include
+ * the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
+ * Header, with the fields enclosed by brackets [] replaced by your own identifying
+ * information: "Portions Copyright [year] [name of copyright owner]".
+ *
+ * Copyright 2026 Wren Security
+ */
+package org.opends.server.extensions;
+
+import static org.testng.Assert.assertTrue;
+
+import org.forgerock.opendj.ldap.ByteString;
+import org.forgerock.opendj.server.config.meta.PBKDF2HmacSHA256PasswordStorageSchemeCfgDefn;
+import org.opends.server.api.PasswordStorageScheme;
+import org.opends.server.types.DirectoryException;
+import org.testng.annotations.Test;
+
+/**
+ * A set of test cases for the PBKDF2-HMAC-SHA256 password storage scheme.
+ */
+public class PBKDF2HmacSHA256PasswordStorageSchemeTestCase extends PasswordStorageSchemeTestCase {
+
+    /**
+     * The published PBKDF2 test vector for the password "password", the salt "salt"
+     * and 4096 iterations, encoded the way this scheme stores it: the iteration
+     * count, a colon, then the base64 encoding of the derived key followed by the
+     * salt.
+     */
+    private final String PASSWORD = "4096:xeR41ZKIyEGqUw22hFxMjZYok6ABzk4RpJY4c6qYE0pzYWx0";
+
+    public PBKDF2HmacSHA256PasswordStorageSchemeTestCase() {
+        super("cn=PBKDF2-HMAC-SHA256,cn=Password Storage Schemes,cn=config");
+    }
+
+    /**
+     * Verifies that this scheme interoperates with the published PBKDF2
+     * HMAC-SHA-256 test vector, which pins both the key derivation and the way the
+     * derived key and salt are encoded.
+     */
+    @Test
+    public void testKnownVectorMatches() throws Exception {
+        assertTrue(getScheme().passwordMatches(ByteString.valueOfUtf8("password"),
+                ByteString.valueOfUtf8(PASSWORD)));
+    }
+
+    /**
+     * Verifies that the same published test vector is matched through the
+     * authentication password syntax, where the salt and the derived key are
+     * encoded separately.
+     */
+    @Test
+    public void testKnownVectorMatchesAuthPassword() throws Exception {
+        assertTrue(getScheme().authPasswordMatches(ByteString.valueOfUtf8("password"),
+                "4096:c2FsdA==", "xeR41ZKIyEGqUw22hFxMjZYok6ABzk4RpJY4c6qYE0o="));
+    }
+
+    @Override
+    protected PasswordStorageScheme<?> getScheme() throws Exception {
+        return InitializationUtils.initializePasswordStorageScheme(new PBKDF2HmacSHA256PasswordStorageScheme(),
+                configEntry, PBKDF2HmacSHA256PasswordStorageSchemeCfgDefn.getInstance());
+    }
+
+    @Override
+    protected String encodeOffline(final byte[] plaintextBytes) throws DirectoryException {
+        return PBKDF2HmacSHA256PasswordStorageScheme.encodeOffline(plaintextBytes);
+    }
+}

--- a/opendj-server-legacy/src/test/java/org/opends/server/extensions/PBKDF2HmacSHA512PasswordStorageSchemeTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/extensions/PBKDF2HmacSHA512PasswordStorageSchemeTestCase.java
@@ -1,0 +1,76 @@
+/*
+ * The contents of this file are subject to the terms of the Common Development and
+ * Distribution License (the License). You may not use this file except in compliance with the
+ * License.
+ *
+ * You can obtain a copy of the License at legal/CDDLv1.0.txt. See the License for the
+ * specific language governing permission and limitations under the License.
+ *
+ * When distributing Covered Software, include this CDDL Header Notice in each file and include
+ * the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
+ * Header, with the fields enclosed by brackets [] replaced by your own identifying
+ * information: "Portions Copyright [year] [name of copyright owner]".
+ *
+ * Copyright 2026 Wren Security
+ */
+package org.opends.server.extensions;
+
+import static org.testng.Assert.assertTrue;
+
+import org.forgerock.opendj.ldap.ByteString;
+import org.forgerock.opendj.server.config.meta.PBKDF2HmacSHA512PasswordStorageSchemeCfgDefn;
+import org.opends.server.api.PasswordStorageScheme;
+import org.opends.server.types.DirectoryException;
+import org.testng.annotations.Test;
+
+/**
+ * A set of test cases for the PBKDF2-HMAC-SHA512 password storage scheme.
+ */
+public class PBKDF2HmacSHA512PasswordStorageSchemeTestCase extends PasswordStorageSchemeTestCase {
+
+    /**
+     * The published PBKDF2 test vector for the password "password", the salt "salt"
+     * and 4096 iterations, encoded the way this scheme stores it: the iteration
+     * count, a colon, then the base64 encoding of the derived key followed by the
+     * salt.
+     */
+    private static final String PASSWORD = "4096:0Zexsz2wFD4BixLz0dFHnmzevcyXxcD4f2kC4"
+            + "HL0V7UUPzBgJkGz1VzTNZiMs2uEN2Bg7NUy4Dm3QqI5Q0ry1XNhbHQ=";
+
+    public PBKDF2HmacSHA512PasswordStorageSchemeTestCase() {
+        super("cn=PBKDF2-HMAC-SHA512,cn=Password Storage Schemes,cn=config");
+    }
+
+    /**
+     * Verifies that this scheme interoperates with the published PBKDF2
+     * HMAC-SHA-512 test vector, which pins both the key derivation and the way the
+     * derived key and salt are encoded.
+     */
+    @Test
+    public void testKnownVectorMatches() throws Exception {
+        assertTrue(getScheme().passwordMatches(ByteString.valueOfUtf8("password"),
+                ByteString.valueOfUtf8(PASSWORD)));
+    }
+
+    /**
+     * Verifies that the same published test vector is matched through the
+     * authentication password syntax, where the salt and the derived key are
+     * encoded separately.
+     */
+    @Test
+    public void testKnownVectorMatchesAuthPassword() throws Exception {
+        assertTrue(getScheme().authPasswordMatches(ByteString.valueOfUtf8("password"), "4096:c2FsdA==",
+                "0Zexsz2wFD4BixLz0dFHnmzevcyXxcD4f2kC4HL0V7UUPzBgJkGz1VzTNZiMs2uEN2Bg7NUy4Dm3QqI5Q0ry1Q=="));
+    }
+
+    @Override
+    protected PasswordStorageScheme<?> getScheme() throws Exception {
+        return InitializationUtils.initializePasswordStorageScheme(new PBKDF2HmacSHA512PasswordStorageScheme(),
+                configEntry, PBKDF2HmacSHA512PasswordStorageSchemeCfgDefn.getInstance());
+    }
+
+    @Override
+    protected String encodeOffline(final byte[] plaintextBytes) throws DirectoryException {
+        return PBKDF2HmacSHA512PasswordStorageScheme.encodeOffline(plaintextBytes);
+    }
+}

--- a/opendj-server-legacy/src/test/java/org/opends/server/extensions/PBKDF2PasswordStorageSchemeTestCase.java
+++ b/opendj-server-legacy/src/test/java/org/opends/server/extensions/PBKDF2PasswordStorageSchemeTestCase.java
@@ -18,56 +18,24 @@ package org.opends.server.extensions;
 import org.forgerock.opendj.server.config.meta.PBKDF2PasswordStorageSchemeCfgDefn;
 import org.opends.server.api.PasswordStorageScheme;
 import org.opends.server.types.DirectoryException;
-import org.testng.annotations.DataProvider;
 
 /**
  * A set of test cases for the PBKDF2 password storage scheme.
  */
-@SuppressWarnings("javadoc")
-public class PBKDF2PasswordStorageSchemeTestCase
-       extends PasswordStorageSchemeTestCase
-{
-  /** Creates a new instance of this storage scheme test case.   */
-  public PBKDF2PasswordStorageSchemeTestCase()
-  {
-    super("cn=PBKDF2,cn=Password Storage Schemes,cn=config");
-  }
+public class PBKDF2PasswordStorageSchemeTestCase extends PasswordStorageSchemeTestCase {
 
-  /**
-   * Retrieves a set of passwords that may be used to test the password storage scheme.
-   *
-   * @return  A set of passwords that may be used to test the password storage scheme.
-   */
-  @Override
-  @DataProvider(name = "testPasswords")
-  public Object[][] getTestPasswords()
-  {
-    final Object[][] testPasswords = super.getTestPasswords();
+    public PBKDF2PasswordStorageSchemeTestCase() {
+        super("cn=PBKDF2,cn=Password Storage Schemes,cn=config");
+    }
 
-    // JDK Bug 6879540. Empty passwords are not accepted when generating PBESpecKey.
-    // The bug is present in Java 6 and some version of Java 7.
-    final int newLength = testPasswords.length - 2;
-    final Object[][] results = new Object[newLength][];
-    System.arraycopy(testPasswords, 2, results, 0, newLength);
-    return results;
-  }
+    @Override
+    protected PasswordStorageScheme<?> getScheme() throws Exception {
+        return InitializationUtils.initializePasswordStorageScheme(new PBKDF2PasswordStorageScheme(), configEntry,
+                PBKDF2PasswordStorageSchemeCfgDefn.getInstance());
+    }
 
-
-  /**
-   * Retrieves an initialized instance of this password storage scheme.
-   *
-   * @return  An initialized instance of this password storage scheme.
-   */
-  @Override
-  protected PasswordStorageScheme<?> getScheme() throws Exception
-  {
-    return InitializationUtils.initializePasswordStorageScheme(
-        new PBKDF2PasswordStorageScheme(), configEntry, PBKDF2PasswordStorageSchemeCfgDefn.getInstance());
-  }
-
-  @Override
-  protected String encodeOffline(final byte[] plaintextBytes) throws DirectoryException
-  {
-    return PBKDF2PasswordStorageScheme.encodeOffline(plaintextBytes);
-  }
+    @Override
+    protected String encodeOffline(final byte[] plaintextBytes) throws DirectoryException {
+        return PBKDF2PasswordStorageScheme.encodeOffline(plaintextBytes);
+    }
 }


### PR DESCRIPTION
This PR adds two password storage schemes based on PBKDF2 (RFC 2898) using HMAC-SHA-256 and HMAC-SHA-512 as the pseudo-random function, and refactors the existing `PBKDF2` (HMAC-SHA1) scheme onto a shared base class.

Both schemes support the user password syntax (e.g. `{PBKDF2-HMAC-SHA256}`) and the authentication password syntax, are enabled by default, and are one-way (non-reversible).

### Iteration defaults

| Scheme | Default | Measured cost per bind |
|---|---|---|
| `PBKDF2-HMAC-SHA256` | 600,000 | ~91 ms |
| `PBKDF2-HMAC-SHA512` | 220,000 | ~117 ms |
| `PBKDF2` (HMAC-SHA1) | 10,000 (unchanged) | ~2 ms |

The two new defaults are the counts currently recommended by the OWASP Password Storage Cheat Sheet. Costs measured single-threaded on a Ryzen 7 7700X, JDK 21, SunJCE; a slower server core will cost proportionally more.

Deployments that need more can lower `ds-cfg-pbkdf2-iterations` per instance.

### Salt length raised to 128 bits

`NUM_SALT_BYTES` goes from 8 to 16, for all three PBKDF2 schemes. NIST SP 800-132 §5.1 requires at least 128 bits of randomly generated salt for PBKDF2 — a SHALL — and 64 bits did not meet it. This also matches the 16 bytes already used by `PKCS5S2`, the other PBKDF2-based scheme in the tree.

This is backward compatible in both directions:

- Existing values verify unchanged, because the read path derives the salt length from the stored value (`decodedBytes.length - digestLength`) rather than assuming it; the authentication password syntax encodes the salt as its own base64 field and is likewise length-agnostic.
- Values written with the new 16-byte salt verify on older WrenDS builds, because the pre-refactor implementation derived the length the same way. So a mixed replication topology or a downgrade will not break authentication.

Existing stored passwords keep their 64-bit salt until they are next re-encoded.

### Configuration and schema

- Two managed object definitions, `pbkdf2-hmac-sha256-password-storage-scheme` and `pbkdf2-hmac-sha512-password-storage-scheme`, reusing the existing `ds-cfg-pbkdf2-iterations` attribute.
- Two `objectClasses` in `02-config.ldif` (OIDs `1.3.6.1.4.1.64165.2.1.2.1` and `.2`).
- Both schemes enabled by default in `config.ldif`.
- Upgrade tasks registered under `5.1.2` add the config entries to existing installations. The schema itself needs no task, as every upgrade already refreshes `02-config.ldif` via `registerLast(copySchemaFile(...))`.
- The `encode-password -l` man-page example is updated to list the new schemes.

### Migrating existing users

Existing passwords cannot be upgraded in place, but they can be migrated transparently through normal authentication, by setting on the password policy:

    ds-cfg-default-password-storage-scheme: PBKDF2-HMAC-SHA256
    ds-cfg-deprecated-password-storage-scheme: PBKDF2

Each user's password is then re-encoded with the new scheme, iteration count and salt length on their next successful bind, with no password resets. This works because the re-encode logic keys on the scheme name; it will not fire for changes within a single scheme.

Fixes https://github.com/WrenSecurity/wrends/issues/82.